### PR TITLE
release: 1.1.0 - API cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ by area: **Annotations**, **Runtime**, **Build-time**, **DX**, **Migrations**,
 
 _No changes yet._
 
+## [1.1.0] - 2026-05-02
+
+API cleanup release. No new features. Sharpens the SPI surface that 1.0.0 froze
+where a senior code review surfaced smells worth fixing before the first
+external adopter.
+
+### Changed (BREAKING for SPI implementers, not for application users)
+- **`ErasureHandler.entityType()` now returns `Class<?>` instead of `String`.**
+  Implementations change from `return Customer.class.getName();` to
+  `return Customer.class;`. Wire format unchanged: the
+  `DELETE /gdpr/erasure/{subjectId}` response still maps `affectedByType` keys
+  to the type's fully qualified name (Jackson serialises `Class<?>` map keys
+  as FQN strings).
+- **`RetentionTarget.entityType()` now returns `Class<?>` instead of `String`.**
+  Same migration as above. Used in retention sweep logs only, no wire impact.
+
+Why: the previous String FQN coupling was stringly-typed. A renamed entity
+slipped through to the audit row at runtime instead of failing at compile
+time. Returning `Class<?>` puts the contract on the type system.
+
+### Docs
+- `@GdprErasable.subjectIdField` Javadoc now states explicitly that the value
+  is documentation surfaced in the DPIA, not a runtime lookup driver. Adopters
+  who wanted custom subject-id resolution were already supposed to override the
+  `SubjectIdResolver` bean; this is now documented at the annotation level
+  instead of being buried in the README's "Reality check" section.
+
 ## [1.0.0] - 2026-05-02
 
 First stable release. API freeze for the five `@Gdpr*` annotations, the

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ flowchart LR
 <dependency>
   <groupId>com.github.iambilotta.spring-gdpr</groupId>
   <artifactId>spring-gdpr-starter</artifactId>
-  <version>v1.0.0</version>
+  <version>v1.1.0</version>
 </dependency>
 ```
 
@@ -175,7 +175,7 @@ flowchart LR
       <path>
         <groupId>com.github.iambilotta.spring-gdpr</groupId>
         <artifactId>spring-gdpr-processor</artifactId>
-        <version>v1.0.0</version>
+        <version>v1.1.0</version>
       </path>
     </annotationProcessorPaths>
   </configuration>
@@ -198,7 +198,7 @@ classpath:db/migration/V1__gdpr_audit_access.sql
 <plugin>
   <groupId>com.github.iambilotta.spring-gdpr</groupId>
   <artifactId>spring-gdpr-maven-plugin</artifactId>
-  <version>v1.0.0</version>
+  <version>v1.1.0</version>
   <executions><execution><goals><goal>verify</goal></goals></execution></executions>
 </plugin>
 ```

--- a/examples/quickstart-postgres/pom.xml
+++ b/examples/quickstart-postgres/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <spring-gdpr.version>0.1.1</spring-gdpr.version>
+        <spring-gdpr.version>1.1.0</spring-gdpr.version>
     </properties>
 
     <dependencies>

--- a/examples/quickstart-postgres/src/main/java/com/example/gdprdemo/CustomerErasureHandler.java
+++ b/examples/quickstart-postgres/src/main/java/com/example/gdprdemo/CustomerErasureHandler.java
@@ -15,8 +15,8 @@ public class CustomerErasureHandler implements ErasureHandler {
     }
 
     @Override
-    public String entityType() {
-        return Customer.class.getName();
+    public Class<?> entityType() {
+        return Customer.class;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.iambilotta.gdpr</groupId>
     <artifactId>spring-gdpr-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>spring-gdpr (parent)</name>

--- a/spring-gdpr-annotations/pom.xml
+++ b/spring-gdpr-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-gdpr-annotations</artifactId>

--- a/spring-gdpr-annotations/src/main/java/com/iambilotta/gdpr/annotations/GdprErasable.java
+++ b/spring-gdpr-annotations/src/main/java/com/iambilotta/gdpr/annotations/GdprErasable.java
@@ -8,11 +8,11 @@ import java.lang.annotation.Target;
 /**
  * Marks a type as participating in the right-to-erasure flow (Art. 17).
  *
- * <p>The erasure REST endpoint locates all {@code @GdprErasable} types whose records
- * reference the requested subject id, then applies the declared {@link #strategy()}.
- *
- * <p>Use {@link #subjectIdField()} to override the default field name used to bind
- * a record to a data subject.
+ * <p>The erasure REST endpoint discovers every {@code ErasureHandler} bean, calls
+ * {@code erase(subjectId)} on each in {@link #order()} ascending, and aggregates the
+ * affected counts per type into the response. The {@code @GdprErasable} annotation
+ * declares the user-visible metadata of the participation; the actual lookup logic
+ * lives in the {@code ErasureHandler} implementation you provide.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -21,7 +21,18 @@ public @interface GdprErasable {
     Strategy strategy() default Strategy.DELETE;
 
     /**
-     * Field name on the annotated entity that holds the subject identifier. Defaults to "subjectId".
+     * Documentation hint about which field on the annotated entity holds the subject
+     * identifier. Surfaced in the generated DPIA so a reviewer can spot the binding
+     * at a glance.
+     *
+     * <p><strong>This value does not drive the erasure lookup.</strong> The actual
+     * lookup is whatever your {@code ErasureHandler.erase(subjectId)} does, with the
+     * subject id resolved by {@code SubjectIdResolver} (default: a method parameter
+     * literally named {@code subjectId}, case-insensitive). To change the lookup
+     * strategy, override the {@code SubjectIdResolver} bean or pass the id explicitly.
+     *
+     * <p>Kept as documentation because GDPR audits expect a clear record of which
+     * column on each table is the subject foreign key.
      */
     String subjectIdField() default "subjectId";
 

--- a/spring-gdpr-maven-plugin/pom.xml
+++ b/spring-gdpr-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-gdpr-maven-plugin</artifactId>

--- a/spring-gdpr-processor/pom.xml
+++ b/spring-gdpr-processor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-gdpr-processor</artifactId>

--- a/spring-gdpr-starter-test/pom.xml
+++ b/spring-gdpr-starter-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-gdpr-starter-test</artifactId>

--- a/spring-gdpr-starter-test/src/main/java/com/iambilotta/gdpr/demo/CustomerErasureHandler.java
+++ b/spring-gdpr-starter-test/src/main/java/com/iambilotta/gdpr/demo/CustomerErasureHandler.java
@@ -15,8 +15,8 @@ public class CustomerErasureHandler implements ErasureHandler {
     }
 
     @Override
-    public String entityType() {
-        return Customer.class.getName();
+    public Class<?> entityType() {
+        return Customer.class;
     }
 
     @Override

--- a/spring-gdpr-starter/pom.xml
+++ b/spring-gdpr-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>spring-gdpr-starter</artifactId>

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureHandler.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureHandler.java
@@ -11,7 +11,16 @@ import com.iambilotta.gdpr.annotations.GdprErasable;
  */
 public interface ErasureHandler {
 
-    String entityType();
+    /**
+     * The domain type this handler erases for. Used as the key under
+     * {@code affectedByType} in the {@code DELETE /gdpr/erasure/{subjectId}}
+     * response and in the audit row {@code targetType} field.
+     *
+     * <p>Returning {@link Class} instead of a free-form FQN string keeps the
+     * coupling to the type system: a typo or a renamed class fails at compile
+     * time, not at audit-export time.
+     */
+    Class<?> entityType();
 
     GdprErasable.Strategy strategy();
 

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureService.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureService.java
@@ -32,10 +32,11 @@ public class ErasureService {
         Map<String, Integer> affectedByType = new LinkedHashMap<>();
         for (ErasureHandler handler : handlers) {
             int affected = handler.erase(subjectId);
-            affectedByType.put(handler.entityType(), affected);
+            String entityFqn = handler.entityType().getName();
+            affectedByType.put(entityFqn, affected);
             LOG.info(
                     "gdpr_erasure entity={} strategy={} subject={} affected={}",
-                    handler.entityType(),
+                    entityFqn,
                     handler.strategy(),
                     subjectId,
                     affected
@@ -45,6 +46,6 @@ public class ErasureService {
     }
 
     public List<String> registeredTypes() {
-        return handlers.stream().map(ErasureHandler::entityType).toList();
+        return handlers.stream().map(h -> h.entityType().getName()).toList();
     }
 }

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/retention/RetentionScheduler.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/retention/RetentionScheduler.java
@@ -44,7 +44,7 @@ public class RetentionScheduler {
             if (affected > 0) {
                 LOG.info(
                         "gdpr_retention applied entity={} strategy={} cutoff={} affected={}",
-                        target.entityType(),
+                        target.entityType().getName(),
                         target.strategy(),
                         cutoff,
                         affected

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/retention/RetentionTarget.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/retention/RetentionTarget.java
@@ -16,9 +16,12 @@ import com.iambilotta.gdpr.annotations.GdprRetention;
 public interface RetentionTarget {
 
     /**
-     * FQN of the annotated entity. Used in logs and ROPA exports.
+     * The annotated entity class. Used in logs and ROPA exports.
+     *
+     * <p>Returning {@link Class} instead of an FQN string keeps the contract type-safe:
+     * a renamed class fails at compile time, not at retention-sweep time.
      */
-    String entityType();
+    Class<?> entityType();
 
     /**
      * Effective retention period derived from the annotation.

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureServiceTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureServiceTest.java
@@ -12,23 +12,30 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ErasureServiceTest {
 
+    static class Address {}
+    static class Customer {}
+    static class Invoice {}
+
     @Test
     void invokesHandlersInOrderAscending() {
         List<String> invocationOrder = new ArrayList<>();
-        FakeHandler addresses = new FakeHandler("Address", 50, invocationOrder, 0);
-        FakeHandler customers = new FakeHandler("Customer", 100, invocationOrder, 0);
-        FakeHandler invoices = new FakeHandler("Invoice", 25, invocationOrder, 0);
+        FakeHandler addresses = new FakeHandler(Address.class, 50, invocationOrder, 0);
+        FakeHandler customers = new FakeHandler(Customer.class, 100, invocationOrder, 0);
+        FakeHandler invoices = new FakeHandler(Invoice.class, 25, invocationOrder, 0);
 
         ErasureService service = new ErasureService(List.of(addresses, customers, invoices));
         service.eraseSubject("subject-x");
 
-        assertThat(invocationOrder).containsExactly("Invoice", "Address", "Customer");
+        assertThat(invocationOrder).containsExactly(
+                Invoice.class.getName(),
+                Address.class.getName(),
+                Customer.class.getName());
     }
 
     @Test
     void aggregatesAffectedCountsByType() {
-        FakeHandler customers = new FakeHandler("Customer", 100, new ArrayList<>(), 1);
-        FakeHandler invoices = new FakeHandler("Invoice", 50, new ArrayList<>(), 3);
+        FakeHandler customers = new FakeHandler(Customer.class, 100, new ArrayList<>(), 1);
+        FakeHandler invoices = new FakeHandler(Invoice.class, 50, new ArrayList<>(), 3);
 
         ErasureService service = new ErasureService(List.of(customers, invoices));
         ErasureReport report = service.eraseSubject("subject-x");
@@ -36,8 +43,8 @@ class ErasureServiceTest {
         assertThat(report.subjectId()).isEqualTo("subject-x");
         assertThat(report.totalAffected()).isEqualTo(4);
         assertThat(report.affectedByType())
-                .containsEntry("Customer", 1)
-                .containsEntry("Invoice", 3);
+                .containsEntry(Customer.class.getName(), 1)
+                .containsEntry(Invoice.class.getName(), 3);
     }
 
     @Test
@@ -52,21 +59,21 @@ class ErasureServiceTest {
 
     private static final class FakeHandler implements ErasureHandler {
 
-        private final String name;
+        private final Class<?> type;
         private final int order;
         private final List<String> log;
         private final int affected;
 
-        FakeHandler(String name, int order, List<String> log, int affected) {
-            this.name = name;
+        FakeHandler(Class<?> type, int order, List<String> log, int affected) {
+            this.type = type;
             this.order = order;
             this.log = log;
             this.affected = affected;
         }
 
         @Override
-        public String entityType() {
-            return name;
+        public Class<?> entityType() {
+            return type;
         }
 
         @Override
@@ -76,7 +83,7 @@ class ErasureServiceTest {
 
         @Override
         public int erase(String subjectId) {
-            log.add(name);
+            log.add(type.getName());
             return affected;
         }
 

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/retention/RetentionSchedulerTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/retention/RetentionSchedulerTest.java
@@ -15,13 +15,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class RetentionSchedulerTest {
 
+    static class Customer {}
+    static class AccessLog {}
+    static class Anything {}
+    static class A {}
+    static class B {}
+    static class C {}
+
     @Test
     void sweepAppliesEachTargetWithCutoffDerivedFromInjectedClock() {
         Instant fixedNow = Instant.parse("2030-01-01T00:00:00Z");
         Clock clock = Clock.fixed(fixedNow, ZoneOffset.UTC);
 
-        FakeTarget customers = new FakeTarget("Customer", Duration.ofDays(365 * 5L), GdprRetention.Strategy.ANONYMIZE);
-        FakeTarget logs = new FakeTarget("AccessLog", Duration.ofDays(90), GdprRetention.Strategy.DELETE);
+        FakeTarget customers = new FakeTarget(Customer.class, Duration.ofDays(365 * 5L), GdprRetention.Strategy.ANONYMIZE);
+        FakeTarget logs = new FakeTarget(AccessLog.class, Duration.ofDays(90), GdprRetention.Strategy.DELETE);
         RetentionScheduler scheduler = new RetentionScheduler(List.of(customers, logs), clock);
 
         scheduler.sweep();
@@ -34,7 +41,7 @@ class RetentionSchedulerTest {
     void runWithOffsetUsesCallerProvidedDuration() {
         Instant fixedNow = Instant.parse("2030-06-15T12:00:00Z");
         Clock clock = Clock.fixed(fixedNow, ZoneOffset.UTC);
-        FakeTarget target = new FakeTarget("Anything", Duration.ofDays(30), GdprRetention.Strategy.DELETE);
+        FakeTarget target = new FakeTarget(Anything.class, Duration.ofDays(30), GdprRetention.Strategy.DELETE);
         RetentionScheduler scheduler = new RetentionScheduler(List.of(target), clock);
 
         scheduler.runWithOffset(Duration.ofDays(7));
@@ -45,9 +52,9 @@ class RetentionSchedulerTest {
     @Test
     void targetCountReflectsRegisteredTargets() {
         RetentionScheduler scheduler = new RetentionScheduler(List.of(
-                new FakeTarget("A", Duration.ofDays(1), GdprRetention.Strategy.DELETE),
-                new FakeTarget("B", Duration.ofDays(1), GdprRetention.Strategy.DELETE),
-                new FakeTarget("C", Duration.ofDays(1), GdprRetention.Strategy.DELETE)
+                new FakeTarget(A.class, Duration.ofDays(1), GdprRetention.Strategy.DELETE),
+                new FakeTarget(B.class, Duration.ofDays(1), GdprRetention.Strategy.DELETE),
+                new FakeTarget(C.class, Duration.ofDays(1), GdprRetention.Strategy.DELETE)
         ));
 
         assertThat(scheduler.targetCount()).isEqualTo(3);
@@ -55,20 +62,20 @@ class RetentionSchedulerTest {
 
     private static final class FakeTarget implements RetentionTarget {
 
-        private final String name;
+        private final Class<?> type;
         private final Duration period;
         private final GdprRetention.Strategy strategy;
         private final List<Instant> cutoffsObserved = new ArrayList<>();
 
-        FakeTarget(String name, Duration period, GdprRetention.Strategy strategy) {
-            this.name = name;
+        FakeTarget(Class<?> type, Duration period, GdprRetention.Strategy strategy) {
+            this.type = type;
             this.period = period;
             this.strategy = strategy;
         }
 
         @Override
-        public String entityType() {
-            return name;
+        public Class<?> entityType() {
+            return type;
         }
 
         @Override


### PR DESCRIPTION
## Summary

API cleanup release. No new features. Sharpens the SPI surface that 1.0.0 froze where a senior code review surfaced smells worth fixing before the first external adopter.

## Changes

### Changed: typed `entityType()` on the SPI

`ErasureHandler.entityType()` and `RetentionTarget.entityType()` now return `Class<?>` instead of `String`. The previous stringly-typed FQN coupling let a renamed entity slip through to runtime audit rows instead of failing at compile time.

Migration for SPI implementers (one-line):

```diff
- public String entityType() { return Customer.class.getName(); }
+ public Class<?> entityType() { return Customer.class; }
```

Wire format unchanged: `DELETE /gdpr/erasure/{subjectId}` still returns `affectedByType` keyed by FQN strings (Jackson serialises `Class<?>` map keys as FQN).

### Docs: `@GdprErasable.subjectIdField` is now explicitly doc-only

The previous Javadoc said "Defaults to `subjectId`", which suggested the value drove the runtime lookup. In practice it is metadata surfaced in the DPIA only; the actual subject resolution lives in `SubjectIdResolver`. New Javadoc states this explicitly. Same surface, much clearer contract.

## Test plan

- [x] `./mvnw -B install` green on full reactor (annotations, starter, processor, plugin, starter-test)
- [x] `ErasureServiceTest` and `RetentionSchedulerTest` updated to use typed Class<?> stubs (named static test classes)
- [x] internal `CustomerErasureHandler` in starter-test and `examples/quickstart-postgres` migrated to the new contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)