### PR TITLE
chore(dx): plumbing for v1.x adopters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{java,xml,yml,yaml,json,md}]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- Thanks for the PR. Keep this template short. -->
+
+## Summary
+
+What does this change. One paragraph.
+
+## Motivation
+
+Linked issue (or link to a GDPR article / DPO request). If there is no issue, write here why this is a good idea.
+
+## Test plan
+
+- [ ] `./mvnw -B verify` green on the full reactor.
+- [ ] New tests cover the behaviour change (or: existing tests cover it, link to which).
+- [ ] `examples/quickstart-postgres` still boots (if the change touches public API).
+
+## Breaking change
+
+- [ ] Yes, documented in `CHANGELOG.md` under `[Unreleased]` with a migration block.
+- [ ] No.
+
+## Sign-off
+
+By submitting this PR, I confirm:
+
+- [ ] My contribution is licensed under Apache 2.0, the same licence as the project.
+- [ ] I have signed off the commit (`git commit -s`). DCO is required.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,20 @@ jobs:
           name: spring-gdpr-evidence
           path: spring-gdpr-starter-test/target/generated-sources/annotations/spring/gdpr/
           if-no-files-found: warn
+
+      - name: upload jacoco aggregate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-jacoco-aggregate
+          path: spring-gdpr-starter-test/target/site/jacoco-aggregate/
+          if-no-files-found: warn
+
+      - name: generate coverage badge
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: spring-gdpr-starter-test/target/site/jacoco-aggregate/jacoco.csv
+          coverage-badge-filename: jacoco.svg
+          generate-coverage-badge: true
+          badges-directory: .github/badges

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+message: "If you reference this library in a paper, blog post, or talk, please cite it like so."
+title: "spring-gdpr: GDPR compliance, generated from your annotations"
+abstract: >
+  A Spring Boot starter and Java annotation processor that turn @Gdpr* annotations
+  on domain types into the GDPR evidence pack: Article 30 ROPA in CSV, Article 35
+  DPIA scaffold in Markdown, a runtime audit log of personal-data accesses
+  (Article 15 export), a right-to-erasure REST flow (Article 17), and a scheduled
+  retention sweep (Article 5(1)(e)). Apache 2.0, no SaaS, evidence stays on your infra.
+type: software
+version: "1.1.0"
+date-released: 2026-05-02
+license: Apache-2.0
+repository-code: "https://github.com/iambilotta/spring-gdpr"
+url: "https://github.com/iambilotta/spring-gdpr"
+keywords:
+  - gdpr
+  - compliance
+  - data-protection
+  - dpia
+  - ropa
+  - spring-boot
+  - annotation-driven
+  - evidence-as-code
+authors:
+  - given-names: Francesco
+    family-names: Bilotta
+    email: francesco@iambilotta.com
+    website: "https://iambilotta.com"

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,43 @@
+# Support
+
+## Where to get help
+
+| You want to | Go to |
+|---|---|
+| Report a bug or unexpected behaviour | [Issues](https://github.com/iambilotta/spring-gdpr/issues/new/choose) |
+| Suggest a feature, new annotation, new endpoint | [Issues](https://github.com/iambilotta/spring-gdpr/issues/new/choose) |
+| Ask whether the library is the right fit for your GDPR scenario | [Discussions](https://github.com/iambilotta/spring-gdpr/discussions) |
+| Ask for GDPR regulation interpretation | [Discussions](https://github.com/iambilotta/spring-gdpr/discussions). The library does not give legal advice; the maintainer is happy to point you to relevant articles and to publicly available guidance, not to your DPO. |
+| Report a vulnerability | [Private security advisory](https://github.com/iambilotta/spring-gdpr/security/advisories/new). Do NOT open a public issue. See [SECURITY.md](SECURITY.md). |
+| Commercial support, integration help, custom adapters | francesco@iambilotta.com |
+
+## Response times
+
+This is an open-source project maintained by one engineer in Europe. SLAs are best-effort:
+
+- **Security advisories**: triaged within 5 working days.
+- **Bugs with a clean reproducer**: triaged within 7 days.
+- **Feature requests**: triaged when the maintainer has bandwidth, no fixed window.
+- **Discussions**: best-effort, usually within a week.
+
+If you need a guaranteed response time, that is what `francesco@iambilotta.com` is for.
+
+## Before opening an issue
+
+- Verify the bug is reproducible against `v1.1.0` or later.
+- Check [existing issues](https://github.com/iambilotta/spring-gdpr/issues?q=) for duplicates.
+- Read the [README](README.md) and the [ADRs](docs/adr/).
+- Strip secrets from your reproducer.
+
+## Versioning and breaking changes
+
+The project follows [Semantic Versioning](https://semver.org/) from v1.0 onward. Breaking changes ship in major bumps and are documented with a migration block in [CHANGELOG.md](CHANGELOG.md). The `0.x` series predates the API freeze; do not assume API stability if you are pinned to a 0.x.
+
+## Out of scope
+
+The maintainer will not:
+
+- Audit your GDPR compliance posture for you.
+- Speak to your Garante / DPA on your behalf.
+- Backport fixes to discontinued versions or to Spring Boot 2.x.
+- Build adapters for non-Spring frameworks as a free request.

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-plugin-plugin.version>3.13.1</maven-plugin-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -150,8 +152,58 @@
                     <artifactId>central-publishing-maven-plugin</artifactId>
                     <version>0.5.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless-maven-plugin.version}</version>
+                    <configuration>
+                        <java>
+                            <includes>
+                                <include>src/main/java/**/*.java</include>
+                                <include>src/test/java/**/*.java</include>
+                            </includes>
+                            <removeUnusedImports/>
+                            <importOrder>
+                                <order>java,javax,jakarta,org,com,</order>
+                            </importOrder>
+                            <trimTrailingWhitespace/>
+                            <endWithNewline/>
+                        </java>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals><goal>report</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals><goal>report-aggregate</goal></goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/site/jacoco-aggregate</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary

DX-only changes. No production code touched.

- SUPPORT.md: where to ask what, response time best-effort, out-of-scope.
- CITATION.cff: GitHub-rendered cite metadata.
- .editorconfig: uniform indentation/EOL/charset across contributors.
- .github/pull_request_template.md: short template enforcing test-plan + DCO check.
- pom.xml: jacoco-maven-plugin wired (prepare-agent + report + report-aggregate at mvn verify). spotless-maven-plugin in pluginManagement.
- .github/workflows/ci.yml: uploads jacoco-aggregate as artifact, generates coverage badge on push to main.

## Test plan

- [x] \`./mvnw -B verify\` green on full reactor.
- [x] Aggregate jacoco report present at \`spring-gdpr-starter-test/target/site/jacoco-aggregate\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)