### PR TITLE
docs(adr): seven ADRs covering the v1.0 → v1.1 design surface

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,21 @@
+# ADR-NNNN: Title
+
+- **Status:** proposed | accepted | superseded by ADR-XXXX | deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+What forces are at play, including technological, regulatory and project-local. Cite the GDPR article, the Spring Boot version, the issue number when relevant. Keep it factual.
+
+## Decision
+
+What we chose. Active voice, present tense.
+
+## Consequences
+
+What becomes easier, what becomes harder, what risks we accepted. Be specific: "this means breaking change for SPI implementers", not "this could affect users".
+
+## Alternatives considered
+
+What else we evaluated, briefly, and why we did not pick it. One paragraph each.

--- a/docs/adr/0001-annotations-as-source-of-truth.md
+++ b/docs/adr/0001-annotations-as-source-of-truth.md
@@ -6,9 +6,9 @@
 
 ## Context
 
-GDPR Articles 30 (ROPA) and 35 (DPIA) require the controller to keep an up-to-date description of every processing activity touching personal data: data subjects, lawful basis, retention, special category flag, related access points. In every audit I have walked into, the same failure mode shows up: a `DPIA-2024-Q3.docx` shared from a colleague who left, describing an architecture that no longer exists. The information was always already in the codebase. The tooling was missing.
+A DPO walking into a GDPR audit needs three artefacts: an Article 30 ROPA, an Article 35 DPIA scaffold, and a defensible answer to "where in your stack does each item live". The first two are documents. The third is the gating question, and where every implementation we have seen falls down: the library that wins is the one whose answer to "where does each ROPA row come from" is "this Java class, that field, this commit".
 
-Three places could conceivably hold this metadata: a YAML config file shipped with the app, a SaaS dashboard configured by humans, or annotations on the entity classes themselves.
+Concretely the data the DPO needs (data-subject categories, lawful basis under Article 6/9/10, retention period, erasure strategy, the FK column that links a record to a subject) has to live somewhere the engineering team already maintains. The realistic candidates are a YAML config under `resources/`, a SaaS governance dashboard, or annotations on the JPA entity itself.
 
 ## Decision
 
@@ -30,3 +30,13 @@ Concretely the five annotations (`@GdprPersonalData`, `@GdprDataSubjects`, `@Gdp
 **SaaS dashboard (OneTrust, Privitar) with the schema kept in their UI.** Adopters pay 25k EUR/year and onboarding cycles, audit data leaves the company, and the dashboard inevitably drifts from what the application actually does. Net negative for our target.
 
 **XML descriptors on the Spring bean side.** Spring has moved past XML config for ten years; there is no audience for "let me write a `<gdpr-personal-data field='email' />`".
+
+## Why this matters
+
+The principle is "the code is the audit-evidence baseline". Every later decision (where to log access, how erasure is orchestrated, when retention runs) defers to it. If a future feature would force the DPO to maintain a separate file, that feature is wrong-shaped. The DPO's hour-long review against the regenerated DPIA is the load-bearing UX of the entire library.
+
+## References
+
+- The five `@Gdpr*` annotations live in `spring-gdpr-annotations/` (zero runtime deps so the module is safe to import from any layer).
+- The annotation processor that turns them into ROPA + DPIA is `spring-gdpr-processor/`. Output goes to `target/generated-sources/annotations/spring/gdpr/`.
+- See `git log --oneline -- spring-gdpr-annotations/src/main/java` for the iteration on the annotation surface before v0.1.0.

--- a/docs/adr/0001-annotations-as-source-of-truth.md
+++ b/docs/adr/0001-annotations-as-source-of-truth.md
@@ -1,0 +1,32 @@
+# ADR-0001: Annotations as the source of truth for GDPR evidence
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+GDPR Articles 30 (ROPA) and 35 (DPIA) require the controller to keep an up-to-date description of every processing activity touching personal data: data subjects, lawful basis, retention, special category flag, related access points. In every audit I have walked into, the same failure mode shows up: a `DPIA-2024-Q3.docx` shared from a colleague who left, describing an architecture that no longer exists. The information was always already in the codebase. The tooling was missing.
+
+Three places could conceivably hold this metadata: a YAML config file shipped with the app, a SaaS dashboard configured by humans, or annotations on the entity classes themselves.
+
+## Decision
+
+The annotations on the domain types are the single source of truth for the GDPR evidence pack. The build-time annotation processor reads them and writes `ropa.csv` + `dpia.md`; the runtime AOP advisor reads the same annotations to decide what to audit and how. Both halves never disagree because they read the same Java symbols.
+
+Concretely the five annotations (`@GdprPersonalData`, `@GdprDataSubjects`, `@GdprLegalBasis`, `@GdprRetention`, `@GdprErasable`) live in a zero-runtime-dependency module `spring-gdpr-annotations`, importable by any layer.
+
+## Consequences
+
+- Refactoring a `Customer` class moves the DPIA entry with it. A DPO who reviews the regenerated DPIA against last quarter's version sees the architecture changes for free.
+- Removing a field annotated `@GdprPersonalData` deletes its row from `dpia.md` at the next `mvn compile`. If the deletion was unintended, code review catches it.
+- The annotations live with the code, which means they live in the version-controlled history that the company already audits. No drift between "the doc" and "the running system" is possible.
+- Deserves repeating: this is the source of truth for the **dossier**, not for the **claim**. If `@GdprRetention(period = "P5Y")` says five years but the actual retention sweep is configured to one year, the dossier and the runtime are still consistent because both read the same annotation; the *retention sweep* is the side that has to be wired to actually purge. Documented in ADR-0005.
+
+## Alternatives considered
+
+**YAML config under `src/main/resources/gdpr.yaml`.** Detached from the Java class it describes. A rename of `Customer` does not move the YAML entry; the file is updated by hand or it drifts. Same failure mode as the Confluence page we are replacing.
+
+**SaaS dashboard (OneTrust, Privitar) with the schema kept in their UI.** Adopters pay 25k EUR/year and onboarding cycles, audit data leaves the company, and the dashboard inevitably drifts from what the application actually does. Net negative for our target.
+
+**XML descriptors on the Spring bean side.** Spring has moved past XML config for ten years; there is no audience for "let me write a `<gdpr-personal-data field='email' />`".

--- a/docs/adr/0002-async-audit-sink-default.md
+++ b/docs/adr/0002-async-audit-sink-default.md
@@ -1,0 +1,36 @@
+# ADR-0002: Async AuditSink decorator on by default
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+The advisor `PersonalDataAccessAdvisor` fires on every method that reads or returns a `@GdprPersonalData` field. In a typical Spring Boot service that also serves traffic, this is the hot path of every CRUD endpoint. The audit write must not become the bottleneck.
+
+Three sink shapes exist:
+
+- synchronous: the advisor blocks until the sink (DB INSERT, log line) returns. Zero data loss. Worst-case latency tail equals the sink's worst-case.
+- asynchronous, unbounded queue: events queue forever. Zero data loss until the JVM runs out of memory.
+- asynchronous, bounded queue with drop-newest: events queue up to `queue-capacity`; beyond that, drop and increment a counter. Bounded memory, observable backpressure.
+
+## Decision
+
+Default is asynchronous, bounded queue with drop-newest, queue-capacity 1024, single-threaded worker. Synchronous mode opt-in via `spring.gdpr.audit.async.enabled=false`. The `dropped` counter is exposed as a Micrometer gauge so adopters can alert on `rate(dropped[5m]) > 0`.
+
+The `AsyncAuditSinkDecorator` wraps the user-provided `AuditSink` bean transparently when the autoconfig path is taken.
+
+## Consequences
+
+- The request thread does not wait on the sink. Under sustained load below `queue-capacity` events/sec/pod the audit log is complete.
+- Above that, events are dropped. The counter is observable, the WARN logs name the dropped event, but the audit log has gaps. Documented in `Reality check` of the README.
+- Production deployments with hard zero-loss requirements can flip `async.enabled=false` and accept request-thread blocking. The library does not pretend you can have zero loss + zero blocking.
+- The decision is reversible per-installation: it is a property, not a code path.
+
+## Alternatives considered
+
+**Synchronous by default.** Rejected because the typical Spring Boot service author who imports the starter does not want a 5x p99 latency increase as the welcome gift. They will switch async ON anyway, and the ones who genuinely need zero-loss are the minority.
+
+**Async with unbounded queue.** Rejected because OOM under load is harder to debug than an observable drop counter.
+
+**Drop-oldest instead of drop-newest.** A coin toss in theory. Drop-newest preserves the older audit chain (which is usually what an audit looks at: yesterday's events, not the events from the last second). Drop-oldest would silently rotate out historical evidence.

--- a/docs/adr/0002-async-audit-sink-default.md
+++ b/docs/adr/0002-async-audit-sink-default.md
@@ -34,3 +34,13 @@ The `AsyncAuditSinkDecorator` wraps the user-provided `AuditSink` bean transpare
 **Async with unbounded queue.** Rejected because OOM under load is harder to debug than an observable drop counter.
 
 **Drop-oldest instead of drop-newest.** A coin toss in theory. Drop-newest preserves the older audit chain (which is usually what an audit looks at: yesterday's events, not the events from the last second). Drop-oldest would silently rotate out historical evidence.
+
+## Why this matters
+
+The principle is "audit must not become the latency tax". An adopter who sees their p99 double after wiring our advisor reverts the dependency the same week and never comes back. Async-by-default is the only choice that lets a Spring Boot service running 100+ req/sec adopt the library without a configuration debate. Zero-loss is opt-in, not default, because the cost of forcing it on everyone is higher than the cost of an observable drop counter.
+
+## References
+
+- `AsyncAuditSinkDecorator` in `spring-gdpr-starter/src/main/java/.../audit/`.
+- Micrometer counters: `spring.gdpr.audit.submitted`, `spring.gdpr.audit.dropped`, `spring.gdpr.audit.failed`.
+- Reality-check table in the README documents the saturation behaviour explicitly.

--- a/docs/adr/0003-build-time-and-runtime-as-two-products.md
+++ b/docs/adr/0003-build-time-and-runtime-as-two-products.md
@@ -31,3 +31,12 @@ Adopters wire only what they need. The README "Two products, one source of truth
 **Single monolithic dependency.** Rejected because forcing the runtime starter on adopters who only need DPIA generation is a friction point that costs more than the maintenance overhead of two artifacts.
 
 **Single dependency with optional auto-configuration.** Rejected because Spring Boot's auto-config still pulls the runtime classes onto the classpath even when disabled by property; the dependency tree stays heavy.
+
+## Why this matters
+
+A library that forces "all or nothing" loses the adopter who only wants half. Splitting the artifacts is a one-time maintenance cost; gluing them together is a permanent friction tax on every adopter who reads the dependency tree. The principle generalises: ship the smallest dependency surface that still produces value.
+
+## References
+
+- Module split: `spring-gdpr-annotations` (zero deps), `spring-gdpr-processor` (build-time only), `spring-gdpr-starter` (runtime).
+- Both halves consume `spring-gdpr-annotations` so semantics never drift between APT and AOP advisor.

--- a/docs/adr/0003-build-time-and-runtime-as-two-products.md
+++ b/docs/adr/0003-build-time-and-runtime-as-two-products.md
@@ -1,0 +1,33 @@
+# ADR-0003: Build-time generator and runtime starter as two separately adoptable halves
+
+- **Status:** accepted
+- **Date:** 2026-05-02
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+The library does two distinct jobs: it generates DPIA + ROPA at build time (annotation processor), and it logs personal-data accesses + handles erasure at runtime (Spring Boot starter). Some teams need only the first half: their DPO wants the dossier, but the application is too small or too low-traffic to justify wiring a runtime audit sink and a `/gdpr/erasure` endpoint. Other teams have already audited their persistence layer and want only the runtime advisor.
+
+A single uber-module forcing both halves together would push adopters who only need one half to drag in dependencies, REST endpoints, and Spring Security configuration they do not use.
+
+## Decision
+
+The two halves ship as separately consumable Maven artifacts:
+
+- `spring-gdpr-annotations` (zero-deps): the five annotations.
+- `spring-gdpr-processor` (build only, JSR 269 annotation processor): generates `ropa.csv` and `dpia.md`.
+- `spring-gdpr-starter` (Spring Boot 3.5+): AOP advisor, REST endpoints, retention sweep, async sink.
+
+Adopters wire only what they need. The README "Two products, one source of truth" section names the split explicitly.
+
+## Consequences
+
+- Smaller blast radius for users in regulated environments who already have an audit log they do not want to replace: take only the processor.
+- More moving parts to maintain. `spring-gdpr-processor` and `spring-gdpr-starter` must agree on annotation semantics (handled by both depending on `spring-gdpr-annotations`).
+- Documentation cost: the README has to explain the split or adopters mis-import.
+
+## Alternatives considered
+
+**Single monolithic dependency.** Rejected because forcing the runtime starter on adopters who only need DPIA generation is a friction point that costs more than the maintenance overhead of two artifacts.
+
+**Single dependency with optional auto-configuration.** Rejected because Spring Boot's auto-config still pulls the runtime classes onto the classpath even when disabled by property; the dependency tree stays heavy.

--- a/docs/adr/0004-erasure-handler-orchestration.md
+++ b/docs/adr/0004-erasure-handler-orchestration.md
@@ -1,0 +1,38 @@
+# ADR-0004: ErasureHandler beans, ordered, audited
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+GDPR Article 17 requires the controller to erase a subject's personal data on request, "without undue delay". A real application keeps personal data in many tables, sometimes in many systems (CRM, mailer, search index). Erasure has dependency order: child rows go before parent rows, otherwise foreign-key constraints reject the delete. Some tables should anonymize rather than delete (statistics, audit history). Each step must be audited so the controller can demonstrate the request was honoured.
+
+An "auto-erasure-by-reflection" mechanism that walks JPA entity graphs at runtime is appealing on the demo slide and broken in production: it cannot speak to non-JPA stores, it cannot anonymize, and it cannot decide cascade order without metadata the entity does not carry.
+
+## Decision
+
+Erasure is performed by user-provided `ErasureHandler` beans, one per type. The library does three things:
+
+1. discovers all `ErasureHandler` beans and orders them by `int order()` ascending,
+2. invokes each on the requested `subjectId`,
+3. emits an audit row per handler (entity type, subject id, strategy, affected count, outcome).
+
+The `DELETE /gdpr/erasure/{subjectId}` REST endpoint returns the per-handler aggregate as `{"subjectId": ..., "affectedByType": {"com.example.Customer": 1, ...}}`. If a handler partially fails the response surfaces it as a 207 Multi-Status with the per-handler outcome list.
+
+`@GdprErasable.subjectIdField` is documentation surfaced in the DPIA, not a runtime lookup driver: see ADR-0007.
+
+## Consequences
+
+- Adopters write one method per table that holds personal data. The library handles ordering, audit and HTTP shape.
+- The library refuses to be opinionated about persistence (JPA, JDBC, MongoDB, external API). The handler pattern works with whatever the adopter's stack already runs.
+- The library cannot guarantee "this subject's data is fully erased" because that depends on whether the adopter wrote a handler for every table. We document this clearly: the audit row says what the library did, not what the system did.
+- The cascade order is the adopter's responsibility, declared via `int order()`. Wrong order shows up as a database FK violation at the first call, which is the right time to fail.
+
+## Alternatives considered
+
+**Reflection-driven cascade walk** as suggested above. Rejected because non-JPA stores are out of reach and anonymize-vs-delete is a semantic decision the framework cannot make.
+
+**Single user-provided "erase everything" bean.** Rejected because it gives up the per-type audit row, which is exactly what an Article 17 review wants to see.
+
+**Auto-discovered Spring Data repositories.** Rejected for the same reason as reflection-driven: it traps the library in a JPA-only world and gives up anonymize semantics.

--- a/docs/adr/0004-erasure-handler-orchestration.md
+++ b/docs/adr/0004-erasure-handler-orchestration.md
@@ -36,3 +36,13 @@ The `DELETE /gdpr/erasure/{subjectId}` REST endpoint returns the per-handler agg
 **Single user-provided "erase everything" bean.** Rejected because it gives up the per-type audit row, which is exactly what an Article 17 review wants to see.
 
 **Auto-discovered Spring Data repositories.** Rejected for the same reason as reflection-driven: it traps the library in a JPA-only world and gives up anonymize semantics.
+
+## Why this matters
+
+The principle is "the library knows orchestration; the application knows the data". Reflection-driven cascades work on slide decks and break the moment a real adopter has Mongo, Redis, or an external CRM. By making `ErasureHandler` user-owned we trade some adopter typing for a library that survives every persistence shape. Article 17 audits care about evidence that the right tables were touched; they do not care that the library walked them automatically.
+
+## References
+
+- `ErasureHandler` SPI: `spring-gdpr-starter/src/main/java/.../erasure/`.
+- `ErasureService` orchestrator: same package. Tests in `spring-gdpr-starter/src/test/java/.../erasure/ErasureServiceTest.java`.
+- Demo handler (single-table delete): see `examples/quickstart-postgres/.../CustomerErasureHandler.java`.

--- a/docs/adr/0005-retention-via-spring-scheduled.md
+++ b/docs/adr/0005-retention-via-spring-scheduled.md
@@ -1,0 +1,35 @@
+# ADR-0005: Retention sweep via @Scheduled, configurable cron
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+GDPR Article 5(1)(e) requires the controller to keep personal data "in a form which permits identification of data subjects for no longer than is necessary". For routine processing this means a scheduled enforcement: a cron job that walks the records, finds those past their `@GdprRetention(period = "P5Y")` window, and applies the declared strategy (DELETE / ANONYMIZE / PSEUDONYMIZE). The library has to decide where this scheduler lives.
+
+Three options:
+
+- An external scheduler (k8s CronJob, systemd timer) calling a REST endpoint.
+- A library-provided `@Scheduled` bean inside the application JVM.
+- A user-provided callback that the adopter wires themselves.
+
+## Decision
+
+The library provides a `RetentionScheduler` bean annotated `@Scheduled(cron = "${spring.gdpr.retention.cron:0 0 3 * * *}")`. The default fires at 03:00 server-local. The cron expression is fully overridable via property.
+
+Adopters who prefer external scheduling set `spring.gdpr.retention.enabled=false` and call `RetentionScheduler.runWithOffset(Duration)` from their own trigger.
+
+## Consequences
+
+- Out-of-the-box: an adopter who imports the starter and applies the migration gets retention enforcement at 03:00 daily. No additional infra wiring required.
+- Single-pod deployments work straight; multi-pod deployments must configure leader election (e.g. via ShedLock) because three pods running the same scheduler triple-call `applyDue`. Documented in the README "Reality check" with a one-line ShedLock recipe deferred to a future minor.
+- The cron expression is a property, so adopters in regulated environments who want all schedules in their own systemd or k8s setup flip the property and call `runWithOffset` from where they already centralise jobs.
+
+## Alternatives considered
+
+**No scheduler, REST endpoint only.** Rejected because the most common adopter (a small Spring Boot service with a part-time DPO) wants retention "to just happen" without standing up a separate cron infrastructure.
+
+**Quartz integration.** Rejected as over-engineering for v1. Spring `@Scheduled` is built-in and good enough for the common case; adopters who already run Quartz configure their own trigger.
+
+**ShedLock bundled.** Rejected for v1: it imposes a database table on every adopter even single-pod ones. Documented as the multi-pod recipe; adopters who need it pull it in themselves.

--- a/docs/adr/0005-retention-via-spring-scheduled.md
+++ b/docs/adr/0005-retention-via-spring-scheduled.md
@@ -33,3 +33,13 @@ Adopters who prefer external scheduling set `spring.gdpr.retention.enabled=false
 **Quartz integration.** Rejected as over-engineering for v1. Spring `@Scheduled` is built-in and good enough for the common case; adopters who already run Quartz configure their own trigger.
 
 **ShedLock bundled.** Rejected for v1: it imposes a database table on every adopter even single-pod ones. Documented as the multi-pod recipe; adopters who need it pull it in themselves.
+
+## Why this matters
+
+The principle is "the smallest infra dependency that still gets the job done". Adding Quartz, ShedLock, or a dedicated cron container is reasonable for some adopters but not for the median Spring Boot service. By defaulting to `@Scheduled` we cover the 80% case with zero extra moving parts; multi-pod deployments still get a documented recipe instead of a hidden gotcha.
+
+## References
+
+- `RetentionScheduler` and `RetentionTarget` SPI in `spring-gdpr-starter/src/main/java/.../retention/`.
+- Cron property: `spring.gdpr.retention.cron`. Tests in `RetentionSchedulerTest`.
+- Multi-pod note: README "Reality check" + future ADR on ShedLock if a real adopter brings the requirement.

--- a/docs/adr/0006-typed-class-on-spi.md
+++ b/docs/adr/0006-typed-class-on-spi.md
@@ -1,0 +1,46 @@
+# ADR-0006: ErasureHandler.entityType() and RetentionTarget.entityType() return Class&lt;?&gt;
+
+- **Status:** accepted
+- **Date:** 2026-05-02
+- **Deciders:** Francesco Bilotta
+- **Supersedes:** the v0.1.x and v1.0.0 SPI shape that returned `String`
+
+## Context
+
+Up to v1.0.0 both SPIs returned the entity FQN as a `String`:
+
+```java
+@Override
+public String entityType() {
+    return Customer.class.getName();
+}
+```
+
+The pattern is stringly-typed: a renamed entity slips through the SPI implementation to the audit row and the retention log, surfacing as a stale FQN in production logs months later. There is no compile-time check.
+
+## Decision
+
+Both `ErasureHandler.entityType()` and `RetentionTarget.entityType()` return `Class<?>`. Implementations:
+
+```java
+@Override
+public Class<?> entityType() {
+    return Customer.class;
+}
+```
+
+Wire format is preserved: `ErasureService.eraseSubject` calls `entityType().getName()` when building the `affectedByType` map, so the JSON response keys still serialise as FQN strings. The `RetentionScheduler` log line emits `entityType().getName()` for the same reason.
+
+## Consequences
+
+- A renamed `Customer` class fails at compile time in every `ErasureHandler` and `RetentionTarget` that referenced it. The auditor never sees a stale FQN.
+- Breaking change for SPI implementers. Migration is one line per implementation. Documented in CHANGELOG `[1.1.0]` with the diff.
+- Wire shape unchanged. Application authors who consume the REST endpoint or grep the logs are unaffected.
+
+## Alternatives considered
+
+**Keep `String` and validate FQN against the runtime classpath at startup.** Rejected: validation runs once at boot but the class can still be missing at audit time (lazy classloading), and the error surface is far worse than a compile-time check.
+
+**`TypeRef<T>` parameterised handler.** Rejected as over-engineering: the type parameter would not buy anything beyond `Class<?>`, and the SPI signature becomes harder to read.
+
+**Defer the change to v2.0.** Rejected because the cost of carrying the stringly-typed signature into a v2 cycle is higher than fixing it in a v1.1 with a clean migration block.

--- a/docs/adr/0006-typed-class-on-spi.md
+++ b/docs/adr/0006-typed-class-on-spi.md
@@ -44,3 +44,13 @@ Wire format is preserved: `ErasureService.eraseSubject` calls `entityType().getN
 **`TypeRef<T>` parameterised handler.** Rejected as over-engineering: the type parameter would not buy anything beyond `Class<?>`, and the SPI signature becomes harder to read.
 
 **Defer the change to v2.0.** Rejected because the cost of carrying the stringly-typed signature into a v2 cycle is higher than fixing it in a v1.1 with a clean migration block.
+
+## Why this matters
+
+The principle is "let the type system catch what it can". Stringly-typed FQN coupling is acceptable in a v0.x prototype where adoption is none and the cost of a breaking change is zero. In v1.x with a published API, every refactor that the compiler can validate is worth a one-line migration block in the CHANGELOG. We pay the cost of the breaking change once, then never again.
+
+## References
+
+- Refactor commit: PR #9, merged on the v1.1.0 release.
+- Wire-format compatibility preserved via `entityType().getName()` at the boundary (ErasureService, RetentionScheduler logs).
+- Migration is one line per `ErasureHandler` / `RetentionTarget` implementation.

--- a/docs/adr/0007-subjectidfield-is-documentation-only.md
+++ b/docs/adr/0007-subjectidfield-is-documentation-only.md
@@ -33,3 +33,13 @@ A future v2 may sunset this property in favour of a typed `subjectId()` referenc
 **Remove the property, force adopters to declare the column elsewhere (XML, DPIA-yaml).** Reintroduces the drift problem the library exists to solve.
 
 **Make the property drive the lookup.** A reflection-driven path forces the library to know the persistence shape (JPA entity, JDBC POJO, Mongo document), which contradicts ADR-0004's decision to keep `ErasureHandler` as a user-owned method.
+
+## Why this matters
+
+The principle is "annotation properties surface in audits, they do not drive runtime". `subjectIdField` exists because a DPO running an audit needs to know which column links a record to a subject; that information belongs in the DPIA. Driving the lookup off it would force the library into a persistence-aware shape (JPA reflection, etc) that ADR-0004 explicitly rejected. Keeping the property and clarifying its semantic is cheaper than renaming.
+
+## References
+
+- Annotation: `spring-gdpr-annotations/src/main/java/.../GdprErasable.java`.
+- Resolver: `SubjectIdResolver` SPI in `spring-gdpr-starter/src/main/java/.../audit/`.
+- Javadoc clarification shipped in the v1.1.0 release.

--- a/docs/adr/0007-subjectidfield-is-documentation-only.md
+++ b/docs/adr/0007-subjectidfield-is-documentation-only.md
@@ -1,0 +1,35 @@
+# ADR-0007: @GdprErasable.subjectIdField is documentation, not a runtime lookup driver
+
+- **Status:** accepted
+- **Date:** 2026-05-02
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+The annotation `@GdprErasable(subjectIdField = "id")` reads naturally as "look up records by the field literally named `id` when erasing". In v0.1.x this misled both adopters and a senior code review pass: the property name suggests it drives the lookup, but the lookup is performed inside the user-provided `ErasureHandler.erase(subjectId)` body, with the `subjectId` resolved by the `SubjectIdResolver` SPI.
+
+Three resolutions were available:
+
+- rename the property (`documentSubjectIdField`, `subjectIdHint`) and break the annotation surface,
+- make the property actually drive the lookup, by reflection on the entity, breaking the SPI,
+- keep the property name and clarify the contract via Javadoc.
+
+## Decision
+
+Keep the property name `subjectIdField` because it is the term DPOs use in audits ("which column is the subject foreign key?"). Document explicitly in the Javadoc that the value is metadata surfaced in the DPIA, not a runtime lookup driver, and that subject-id resolution lives in `SubjectIdResolver`. The clarification shipped in v1.1.0.
+
+A future v2 may sunset this property in favour of a typed `subjectId()` reference, but only if a real adopter request justifies the breaking change.
+
+## Consequences
+
+- Adopters reading the annotation in isolation can still misread it as a lookup directive. The Javadoc is the gating document.
+- The DPIA reviewer (DPO) gets a meaningful "subject id field" column in the generated `dpia.md`, which matches the language used in audits.
+- We accept that the contract relies on Javadoc rather than on the symbol name, and we document the gap in this ADR for future contributors.
+
+## Alternatives considered
+
+**Rename to `documentSubjectIdField`.** More accurate, but a `@Deprecated` migration cycle on a v1 breaking change for cosmetic clarity is too expensive against the marginal benefit.
+
+**Remove the property, force adopters to declare the column elsewhere (XML, DPIA-yaml).** Reintroduces the drift problem the library exists to solve.
+
+**Make the property drive the lookup.** A reflection-driven path forces the library to know the persistence shape (JPA entity, JDBC POJO, Mongo document), which contradicts ADR-0004's decision to keep `ErasureHandler` as a user-owned method.

--- a/docs/adr/0008-consent-and-portability-deferred.md
+++ b/docs/adr/0008-consent-and-portability-deferred.md
@@ -1,0 +1,40 @@
+# ADR-0008: Article 7 consent management and Article 20 portability deferred to a future minor
+
+- **Status:** proposed
+- **Date:** 2026-05-02
+- **Deciders:** Francesco Bilotta
+
+## Context
+
+The library covers Articles 5(1)(e), 6, 9, 10, 15, 17, 30 and 35. It does not cover:
+
+- **Article 7** (consent): proof of explicit, freely-given, informed consent including the wording, the moment, the channel, the withdrawal flow.
+- **Article 20** (data portability): structured machine-readable export of all personal data on request.
+
+Both are real GDPR obligations. Both are out of scope today.
+
+## Decision
+
+Stay deferred. Track each as a future minor (v1.2 or later) under a single ADR rather than letting them creep into v1.1 piecemeal. Document the gap in the README "What this is not" section so adopters in scope-sensitive scenarios know to combine the library with another tool (or build the missing piece on top of `AuditSink` + `ErasureHandler`).
+
+## Why this matters
+
+The principle is "do one thing well in v1, ship the next one when there is an adopter who needs it". Article 7 done badly is worse than not done: a half-built consent ledger that misses a withdrawal event creates legal exposure, not relieves it. We refuse to ship that. Article 20 is a smaller scope than 7, but the export shape (JSON-LD? CSV per entity? PDF dossier?) is something we do not yet have a strong opinion on, and shipping a wrong shape that adopters depend on is harder to fix than not shipping yet.
+
+## Consequences
+
+- Adopters whose primary GDPR risk is consent management (typical for B2C with marketing) will need a separate tool until v1.2+. The README names this clearly.
+- The library is honest about its scope; this is what `Reality check` covers in the README.
+- The maintainer's bandwidth stays focused on hardening the existing surface (audit, erasure, retention, dossier) before broadening.
+
+## Alternatives considered
+
+**Ship a minimum-viable Article 7 in v1.2.** Plausible but requires a real adopter conversation about consent UX, which has not happened.
+
+**Ship Article 20 first because it is smaller.** Considered. Deferred because the export shape decision is not obvious enough to ship without an adopter input.
+
+## References
+
+- Article 7 GDPR: https://gdpr-info.eu/art-7-gdpr/
+- Article 20 GDPR: https://gdpr-info.eu/art-20-gdpr/
+- Roadmap line in `README.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records
+
+Each file under `docs/adr/` records a non-trivial design decision in a fixed format ([Michael Nygard's ADR template](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)). Status, date, context, decision, consequences, alternatives. Short.
+
+The point is honesty: a future contributor (or future me) can re-evaluate a decision with the full context that produced it, instead of guessing from the code.
+
+## Index
+
+- [ADR-0001](0001-annotations-as-source-of-truth.md): Annotations as the source of truth for GDPR evidence.
+- [ADR-0002](0002-async-audit-sink-default.md): Async `AuditSink` decorator on by default.
+- [ADR-0003](0003-build-time-and-runtime-as-two-products.md): Build-time generator and runtime starter as two separately adoptable halves.
+- [ADR-0004](0004-erasure-handler-orchestration.md): `ErasureHandler` beans, ordered, audited.
+- [ADR-0005](0005-retention-via-spring-scheduled.md): Retention sweep via `@Scheduled`, configurable cron.
+- [ADR-0006](0006-typed-class-on-spi.md): `ErasureHandler.entityType()` returns `Class<?>`.
+- [ADR-0007](0007-subjectidfield-is-documentation-only.md): `@GdprErasable.subjectIdField` is documentation, not a runtime lookup driver.
+
+## How to add an ADR
+
+1. Copy `0000-template.md` to the next available number, kebab-case the title.
+2. Set status to `proposed`. Open a PR. After review, flip to `accepted`.
+3. If a later ADR supersedes an earlier one, reference both ways (`Superseded by`, `Supersedes`).
+4. Never delete an old ADR. Mark it `superseded` or `deprecated` and link the replacement.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ The point is honesty: a future contributor (or future me) can re-evaluate a deci
 - [ADR-0005](0005-retention-via-spring-scheduled.md): Retention sweep via `@Scheduled`, configurable cron.
 - [ADR-0006](0006-typed-class-on-spi.md): `ErasureHandler.entityType()` returns `Class<?>`.
 - [ADR-0007](0007-subjectidfield-is-documentation-only.md): `@GdprErasable.subjectIdField` is documentation, not a runtime lookup driver.
+- [ADR-0008](0008-consent-and-portability-deferred.md) [proposed]: Article 7 consent management and Article 20 portability deferred to a future minor.
 
 ## How to add an ADR
 


### PR DESCRIPTION
## Summary

Adds \`docs/adr/\` with seven Michael Nygard ADRs covering the public design surface of v1.0 and v1.1. Plus catalog \`docs/adr/README.md\` and \`0000-template.md\`.

| # | Title |
|---|---|
| 0001 | Annotations as source of truth (vs YAML / SaaS / XML) |
| 0002 | Async sink default with bounded queue + drop-newest |
| 0003 | Build-time generator + runtime starter as two adoptable halves |
| 0004 | ErasureHandler beans, ordered, audited (vs reflection cascade) |
| 0005 | Retention sweep via @Scheduled + property cron |
| 0006 | Typed Class<?> on SPI entityType() |
| 0007 | @GdprErasable.subjectIdField is doc-only |

## Why

For an adopter evaluating the library, "why this shape and not another" is the question that decides adoption. Code answers \`how\`, ADRs answer \`why\`. They will be linked from the README rewrite in the next PR.

## Test plan

No code changed. Verify the .md files render on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)