### PR TITLE
fix(quickstart): migrate QuickstartE2ETest to Spring Security 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,9 @@ jobs:
       - name: install starter to local repo for quickstart build
         run: mvn -B -ntp -DskipTests install
 
-      # Quickstart-postgres tests use Spring Security 6 patterns (@WithMockUser flow,
-      # MockMvc + httpBasic). Spring Security 7 + Spring Boot 4 reworked the test
-      # auth wiring; the quickstart's E2E tests will be re-validated in a follow-up.
-      # Until then, the example must still compile and package against the v2 starter.
-      - name: build quickstart example (compile + package, tests skipped pending Spring Security 7 migration)
+      - name: build quickstart example
         working-directory: examples/quickstart-postgres
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp test
 
       - name: assert dpia + ropa exist
         run: |

--- a/examples/quickstart-postgres/src/test/java/com/example/gdprdemo/QuickstartE2ETest.java
+++ b/examples/quickstart-postgres/src/test/java/com/example/gdprdemo/QuickstartE2ETest.java
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,9 +19,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * sink (slf4j fallback for tests, Postgres in production), erasure REST -> handler ->
  * delete -> aggregate report.
  *
- * <p>Uses an in-process H2 database with auto-create enabled to keep the test self-contained.
- * The shape (controller / repository / advisor / erasure handler / autoconfig wiring) is
- * identical to the production deployment.
+ * <p>Auth pattern: explicit {@code httpBasic(username, password)} request post-processor
+ * on every secured request. Spring Security 7 (Spring Boot 4) tightened the
+ * {@code @WithMockUser} integration with {@code @AutoConfigureMockMvc} so that the
+ * mock authentication no longer auto-applies on every request the way it did in
+ * Spring Security 6 and earlier; using {@code httpBasic} keeps the test independent
+ * of that integration point and matches what a real curl-against-the-running-app
+ * would do.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -40,7 +44,6 @@ class QuickstartE2ETest {
     MockMvc mvc;
 
     @Test
-    @WithMockUser(username = "app", roles = "USER")
     void createCustomerAndFetchHits200() throws Exception {
         String body = """
                 {
@@ -52,12 +55,14 @@ class QuickstartE2ETest {
                 }
                 """;
         mvc.perform(post("/customers")
+                        .with(httpBasic("app", "app-secret"))
                         .contentType("application/json")
                         .content(body))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value("alice-1"));
 
-        mvc.perform(get("/customers/alice-1"))
+        mvc.perform(get("/customers/alice-1")
+                        .with(httpBasic("app", "app-secret")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value("alice@example.com"));
     }
@@ -69,13 +74,13 @@ class QuickstartE2ETest {
     }
 
     @Test
-    @WithMockUser(username = "app", roles = "USER")
     void erasureEndpointForbiddenForNonDpoRole() throws Exception {
-        mvc.perform(delete("/gdpr/erasure/alice-1")).andExpect(status().isForbidden());
+        mvc.perform(delete("/gdpr/erasure/alice-1")
+                        .with(httpBasic("app", "app-secret")))
+                .andExpect(status().isForbidden());
     }
 
     @Test
-    @WithMockUser(username = "dpo", roles = "DPO")
     void erasureEndpointAccessibleToDpoRole() throws Exception {
         String body = """
                 {
@@ -87,12 +92,13 @@ class QuickstartE2ETest {
                 }
                 """;
         mvc.perform(post("/customers")
-                        .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user("app").roles("USER"))
+                        .with(httpBasic("app", "app-secret"))
                         .contentType("application/json")
                         .content(body))
                 .andExpect(status().isOk());
 
-        mvc.perform(delete("/gdpr/erasure/bob-2"))
+        mvc.perform(delete("/gdpr/erasure/bob-2")
+                        .with(httpBasic("dpo", "dpo-secret")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.subjectId").value("bob-2"));
     }


### PR DESCRIPTION
Resolves the Spring Security 7 test-auth gap that the v2.0.0 release deferred.

## Why

Spring Security 7 + Spring Boot 4 tightened the `@WithMockUser` integration with `@AutoConfigureMockMvc`: mock authentication no longer auto-applies on every MockMvc request the way it did in Spring Security 6.

Symptom on PR #18 CI: 401 instead of 200/403 on every secured route.

## What changes

- `QuickstartE2ETest` switched from `@WithMockUser` to explicit `httpBasic(user, pass)` request post-processors on each secured request. More verbose but transparent and independent of `@WithMockUser` auto-application.
- Comment in the test explains the choice for future readers.
- `.github/workflows/ci.yml` restored to `mvn -ntp test` for the quickstart step (was temporarily `-DskipTests package`).

## Test plan

- [x] Local `mvn -B test` in `examples/quickstart-postgres` green: 4 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)