### PR TITLE
Post-erasure SPI: ErasureListener + SubjectErasedEvent (event-sourced consumers can rebuild)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ by area: **Annotations**, **Runtime**, **Build-time**, **DX**, **Migrations**,
   `CompositeSubjectErasureHandler` to erase across both the forgettable store and the crypto key
   store as one unit.
 - **Migrations:** `V3__gdpr_forgettable_payload.sql` (`gdpr_forgettable_payload` external PII store).
+- **Runtime:** post-erasure SPI ([#37](https://github.com/iambilotta/spring-gdpr/issues/37)):
+  `ErasureListener` (`onSubjectErased(ErasureReport)`) and a `SubjectErasedEvent` Spring
+  `ApplicationEvent`, fired once by `ErasureService.eraseSubject` after the handlers commit. The hook
+  for event-sourced / CQRS consumers to rebuild a projection or invalidate a cache that held a
+  now-dangling forgettable-payload reference (ADR-0010). Auto-wired (every `ErasureListener` bean +
+  the context `ApplicationEventPublisher`); a listener failure is surfaced as
+  `ErasureListenerException` and never un-erases the subject. Backward compatible: no-op with no
+  listener (new `ErasureService` constructors, the legacy one preserved).
 
 ### Changed
 - **Docs:** crypto-shredding (ADR-0009) repositioned as the **secondary / exception** mechanism.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,25 @@ It is the secondary path on purpose. Encryption with a separately-held key is, i
 
 When a subject's data is split across both paths, register both handlers (the erasure orchestration runs every handler) or wrap them in a `CompositeSubjectErasureHandler`, which erases across both as one unit and sums the affected counts so neither path is forgotten.
 
+### React after erasure (event-sourced / CQRS rebuilds)
+
+The forgettable-payload pattern leaves the read side with a reference that now resolves to nothing (the same way a crypto-shred drop makes inline ciphertext unreadable). Read models that resolved that reference (a display name on a projection, a cached value) must heal: rebuild the projection, invalidate the cache, re-render the now-opaque ref. After `ErasureService.eraseSubject` honours the request, the library gives you a deterministic signal so you do not poll. Two equivalent hooks, both fire once per successful erasure, after the handlers committed:
+
+```java
+// SPI: implement and register as a bean (no Spring context needed)
+@Bean ErasureListener rebuildProjections(ProjectionRebuilder rebuilder) {
+    return report -> rebuilder.rebuildFor(report.subjectId());   // report.affectedByType() = per-type counts
+}
+
+// or the Spring-native event
+@EventListener
+void onErased(SubjectErasedEvent event) {
+    rebuilder.rebuildFor(event.subjectId());
+}
+```
+
+The erasure has already committed by the time a listener runs, so a listener that throws never un-erases the subject: the other listeners still run and the failure is surfaced as an `ErasureListenerException` (logged, never swallowed) rather than silently lost. Make a listener idempotent, since a rebuild may be retried. With no listener and no `@EventListener` this is a no-op (backward compatible). Pairs with [ADR-0009](docs/adr/0009-append-only-erasure-crypto-shredding.md) / [ADR-0010](docs/adr/0010-forgettable-payload-primary-pattern.md).
+
 ## Annotations
 
 | Annotation | Target | What it does | Where it surfaces |

--- a/docs/requirements/gdpr.requirements.md
+++ b/docs/requirements/gdpr.requirements.md
@@ -292,6 +292,31 @@ And a later write for that subject is refused (tombstone, no resurrection)
 And the audit trail still proves the erasure happened (who, when, why)
 ```
 
+### REQ-GDPR-023 | Post-erasure signal for event-sourced / CQRS consumers (Art.17 follow-on)
+- categoria: funzionale
+- priorità: S
+- fonte: GDPR Art.17 follow-on; dogfooding gap (event-sourced consumers reacting to a forgettable-payload erasure); issue #37
+- rationale: the forgettable-payload pattern (REQ-GDPR-022, ADR-0010) makes a reference unresolvable, and crypto-shredding (REQ-GDPR-016, ADR-0009) makes inline ciphertext unreadable, but a read model / projection that resolved that reference has no signal to rebuild or invalidate, short of polling. The erasure flow had no post-erasure extension point
+- trace-to: `implementato` — `ErasureListener` SPI + `SubjectErasedEvent` (Spring `ApplicationEvent`), fired once by `ErasureService.eraseSubject` after the handlers commit; wired by `GdprAutoConfiguration` (every `ErasureListener` bean + the context `ApplicationEventPublisher`); failure surfaced as `ErasureListenerException` (never un-erases). `ErasureListenerTest` (listener invoked once with the report; no-op + backward-compatible with no listener; a faulty listener is surfaced without swallowing or un-erasing), `GdprAutoConfigurationTest#wiresPostErasureListenerAndPublishesSubjectErasedEvent`
+- depends-on: REQ-GDPR-022
+- stato: implementato
+
+WHEN `ErasureService.eraseSubject` has honoured a subject's erasure across every handler, the system
+SHALL emit exactly one post-erasure signal carrying the report (an `ErasureListener.onSubjectErased`
+invocation and a published `SubjectErasedEvent`), so an event-sourced / CQRS consumer can rebuild a
+projection or invalidate a cache that held a now-dangling reference. With no listener registered the
+emission is a no-op (backward compatible); a listener that fails SHALL surface (logged) and SHALL NOT
+un-erase the subject.
+
+```gherkin
+Given a subject whose erasure is honoured by the registered handlers
+When the erasure completes
+Then every registered ErasureListener is invoked exactly once with the report
+And a SubjectErasedEvent is published for that subject
+And a failing listener is surfaced (not swallowed) while the subject stays erased
+And with no listener registered the erasure still succeeds (no-op)
+```
+
 ### REQ-GDPR-018 | Structured-log PII redaction (Art.5(1)(f))
 - categoria: qos-constraint
 - priorità: S
@@ -353,3 +378,4 @@ not ready in this repo.
 - 2026-06-08 | REQ-GDPR-001..021 | created | first hand-authored EARS to-be spec of the library itself; 14 implementato (each with a hand-verified trace to an existing test/class), 7 proposto (category taxonomy, append-only erasure + its strategy ADR, log-redaction, Art.15 export, plus the ADR-0008 deferred consent/portability); strategy for append-only erasure deferred to a future ADR (REQ-GDPR-017)
 - 2026-06-08 | REQ-GDPR-016, REQ-GDPR-017 | proposto -> implementato | crypto-shredding shipped under ADR-0009 (accepted): per-subject AES-256-GCM key store (`SubjectKeyStore` SPI + JDBC default, `gdpr_subject_key`/V2), `AesGcmCryptoShredder`, `CryptoShreddingErasureHandler` (drop-the-key + audit fact); `CryptoShreddingErasureTest` un-`@Disabled` (4 GREEN) plus `AesGcmCryptoShredderTest`/`JdbcSubjectKeyStoreTest`
 - 2026-06-08 | REQ-GDPR-022 | created -> implementato | forgettable-payload external store made the PRIMARY personal-data erasure path (ADR-0010), crypto-shredding repositioned as the exception (pseudonymisation vs anonymisation, Recital 26 / EDPB 01/2025): `ForgettablePayloadStore` SPI + `JdbcForgettablePayloadStore` (`gdpr_forgettable_payload`/V3) + `InMemoryForgettablePayloadStore`, `ForgettablePayloadReference`, `ForgettablePayloadResolver` (fail-closed), `ForgettablePayloadErasureHandler` (DELETE + audit fact), `CompositeSubjectErasureHandler` (erase across both), `@GdprPersonalData.storage` axis; 27 new GREEN tests across 7 classes
+- 2026-06-17 | REQ-GDPR-023 | created -> implementato | post-erasure SPI (issue #37): `ErasureListener` SPI + `SubjectErasedEvent` fired once by `ErasureService.eraseSubject` after the handlers commit, the hook for event-sourced / CQRS consumers to rebuild a projection that held a now-dangling forgettable-payload reference; wired by `GdprAutoConfiguration` (every listener bean + the context `ApplicationEventPublisher`), failure surfaced as `ErasureListenerException` without un-erasing, no-op + backward-compatible with no listener; `ErasureListenerTest` (3) + `GdprAutoConfigurationTest#wiresPostErasureListenerAndPublishesSubjectErasedEvent`

--- a/spring-gdpr-starter/_generated/modules.md
+++ b/spring-gdpr-starter/_generated/modules.md
@@ -14,7 +14,7 @@ Auto-generated. Modulith convention: each top-level package under `it.housetrees
 | `access` | 5 | 1 | _(none)_ | `jdbc` |
 | `audit` | 9 | 1 | _(none)_ | _(none)_ |
 | `autoconfig` | 1 | 1 | _(none)_ | `access`, `audit`, `erasure`, `retention`, `web` |
-| `erasure` | 18 | 3 | _(none)_ | `audit`, `jdbc` |
+| `erasure` | 21 | 3 | _(none)_ | `audit`, `jdbc` |
 | `jdbc` | 1 | 1 | _(none)_ | _(none)_ |
 | `logging` | 2 | 1 | _(none)_ | _(none)_ |
 | `retention` | 3 | 1 | _(none)_ | `jdbc` |
@@ -91,7 +91,7 @@ component "web"
 
 ### `erasure`
 
-- **Files**: 18
+- **Files**: 21
 - **Sub-packages** (3):
   - `erasure`
   - `erasure.crypto`

--- a/spring-gdpr-starter/_generated/requirements-by-us.md
+++ b/spring-gdpr-starter/_generated/requirements-by-us.md
@@ -4,8 +4,8 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
 
 ## Coverage
 
-- Total tests scanned: **97**
-- Tests linked to a User Story: **62**
+- Total tests scanned: **101**
+- Tests linked to a User Story: **66**
 - Tests without `@spec.us` (implementation detail): **35**
 - User Stories declared in PRODUCT.md: **0**
 - User Stories with at least one linked test: **0**
@@ -120,6 +120,17 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
   - **Then**: construction fails fast before any SQL is built (injection-safe)
 - `FR-erasure.forgettable.JdbcForgettablePayloadStore#resolveOfMissingFieldIsEmpty`
   - **Then**: resolve returns empty (fail-closed: a missing value is never a partial/placeholder)
+
+## `REQ-GDPR-023`  _(unknown to PRODUCT.md)_
+
+- `FR-autoconfig.GdprAutoConfiguration#wiresPostErasureListenerAndPublishesSubjectErasedEvent`
+  - **Then**: both the SPI listener and the @EventListener fire once with the subject (issue #37, the post-erasure hook for event-sourced/CQRS rebuilds)
+- `FR-erasure.ErasureListener#invokesTheListenerOnceWithTheReportAfterErasure`
+  - **Then**: the listener is invoked exactly once with the assembled report
+- `FR-erasure.ErasureListener#isANoOpAndBackwardCompatibleWhenNoListenerIsRegistered`
+  - **Then**: the erasure still succeeds and returns its report (backward compatible no-op)
+- `FR-erasure.ErasureListener#surfacesAListenerFailureWithoutSwallowingOrUnErasing`
+  - **Then**: the failure is surfaced (not swallowed) and the other listeners still ran: the erasure itself already happened, a listener fault never silently un-erases it
 
 ## `US-DX-001-honest-erasure-error-contract`  _(unknown to PRODUCT.md)_
 

--- a/spring-gdpr-starter/_generated/requirements.json
+++ b/spring-gdpr-starter/_generated/requirements.json
@@ -5,10 +5,10 @@
   },
   "label": "spring-gdpr-starter",
   "coverage": {
-    "total": 97,
-    "with_complete_spec": 62,
+    "total": 101,
+    "with_complete_spec": 66,
     "by_category": {
-      "FR": 97
+      "FR": 101
     }
   },
   "requirements": [
@@ -608,6 +608,23 @@
       }
     },
     {
+      "id": "FR-autoconfig.GdprAutoConfiguration#wiresPostErasureListenerAndPublishesSubjectErasedEvent",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "GdprAutoConfiguration",
+      "method": "wiresPostErasureListenerAndPublishesSubjectErasedEvent",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfigurationTest.java",
+      "spec": {
+        "given": "the GDPR autoconfiguration plus a registered ErasureListener and an",
+        "when": "the wired ErasureService erases a subject",
+        "then": "both the SPI listener and the @EventListener fire once with the subject (issue #37, the post-erasure hook for event-sourced/CQRS rebuilds)",
+        "adr": "",
+        "us": "REQ-GDPR-023",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
       "id": "FR-autoconfig.GdprAutoConfiguration#wiresTheAccessExportService",
       "category": "FR",
       "module": "autoconfig",
@@ -705,6 +722,57 @@
         "then": "both replays yield the same read model with the PII blank (idempotent under replay)",
         "adr": "ADR-0009",
         "us": "REQ-GDPR-016",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.ErasureListener#invokesTheListenerOnceWithTheReportAfterErasure",
+      "category": "FR",
+      "module": "erasure",
+      "unit": "ErasureListener",
+      "method": "invokesTheListenerOnceWithTheReportAfterErasure",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java",
+      "spec": {
+        "given": "an ErasureService with one registered ErasureListener",
+        "when": "a subject is erased",
+        "then": "the listener is invoked exactly once with the assembled report",
+        "adr": "",
+        "us": "REQ-GDPR-023",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.ErasureListener#isANoOpAndBackwardCompatibleWhenNoListenerIsRegistered",
+      "category": "FR",
+      "module": "erasure",
+      "unit": "ErasureListener",
+      "method": "isANoOpAndBackwardCompatibleWhenNoListenerIsRegistered",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java",
+      "spec": {
+        "given": "an ErasureService with no listener registered (the legacy constructor)",
+        "when": "a subject is erased",
+        "then": "the erasure still succeeds and returns its report (backward compatible no-op)",
+        "adr": "",
+        "us": "REQ-GDPR-023",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.ErasureListener#surfacesAListenerFailureWithoutSwallowingOrUnErasing",
+      "category": "FR",
+      "module": "erasure",
+      "unit": "ErasureListener",
+      "method": "surfacesAListenerFailureWithoutSwallowingOrUnErasing",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java",
+      "spec": {
+        "given": "an ErasureService with several listeners, one of which throws",
+        "when": "a subject is erased",
+        "then": "the failure is surfaced (not swallowed) and the other listeners still ran: the erasure itself already happened, a listener fault never silently un-erases it",
+        "adr": "",
+        "us": "REQ-GDPR-023",
         "ac": "",
         "complete": true
       }

--- a/spring-gdpr-starter/_generated/requirements.md
+++ b/spring-gdpr-starter/_generated/requirements.md
@@ -6,9 +6,9 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 
 ## Coverage
 
-- Total tests scanned: **97**
-- With complete spec javadoc: **62** (64%)
-- FR: 97
+- Total tests scanned: **101**
+- With complete spec javadoc: **66** (65%)
+- FR: 101
 
 ## Module `access`
 
@@ -220,6 +220,14 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 - _(spec missing — add `@spec.given` / `@spec.when` / `@spec.then` javadoc)_
 - **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfigurationTest.java`
 
+#### `FR-autoconfig.GdprAutoConfiguration#wiresPostErasureListenerAndPublishesSubjectErasedEvent`
+
+- **Given**: the GDPR autoconfiguration plus a registered ErasureListener and an
+- **When**: the wired ErasureService erases a subject
+- **Then**: both the SPI listener and the @EventListener fire once with the subject (issue #37, the post-erasure hook for event-sourced/CQRS rebuilds)
+- **User Story**: REQ-GDPR-023
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfigurationTest.java`
+
 #### `FR-autoconfig.GdprAutoConfiguration#wiresTheAccessExportService`
 
 - **Given**: the GDPR autoconfiguration on the context
@@ -273,6 +281,30 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 - **ADR**: ADR-0009
 - **User Story**: REQ-GDPR-016
 - **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/CryptoShreddingErasureTest.java`
+
+#### `FR-erasure.ErasureListener#invokesTheListenerOnceWithTheReportAfterErasure`
+
+- **Given**: an ErasureService with one registered ErasureListener
+- **When**: a subject is erased
+- **Then**: the listener is invoked exactly once with the assembled report
+- **User Story**: REQ-GDPR-023
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java`
+
+#### `FR-erasure.ErasureListener#isANoOpAndBackwardCompatibleWhenNoListenerIsRegistered`
+
+- **Given**: an ErasureService with no listener registered (the legacy constructor)
+- **When**: a subject is erased
+- **Then**: the erasure still succeeds and returns its report (backward compatible no-op)
+- **User Story**: REQ-GDPR-023
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java`
+
+#### `FR-erasure.ErasureListener#surfacesAListenerFailureWithoutSwallowingOrUnErasing`
+
+- **Given**: an ErasureService with several listeners, one of which throws
+- **When**: a subject is erased
+- **Then**: the failure is surfaced (not swallowed) and the other listeners still ran: the erasure itself already happened, a listener fault never silently un-erases it
+- **User Story**: REQ-GDPR-023
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java`
 
 #### `FR-erasure.ErasureService#aggregatesAffectedCountsByType`
 

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -31,6 +32,7 @@ import com.iambilotta.gdpr.starter.audit.PersonalDataAccessAdvisor;
 import com.iambilotta.gdpr.starter.audit.Slf4jAuditSink;
 import com.iambilotta.gdpr.starter.audit.SubjectIdResolver;
 import com.iambilotta.gdpr.starter.erasure.ErasureHandler;
+import com.iambilotta.gdpr.starter.erasure.ErasureListener;
 import com.iambilotta.gdpr.starter.erasure.ErasureService;
 import com.iambilotta.gdpr.starter.retention.RetentionScheduler;
 import com.iambilotta.gdpr.starter.retention.RetentionTarget;
@@ -113,11 +115,24 @@ public class GdprAutoConfiguration {
         return new PersonalDataAccessAdvisor(sink, actorResolver, subjectIdResolver);
     }
 
+    /**
+     * The Art. 17 orchestrator. Wires every {@link ErasureHandler} the adopter registered, plus the
+     * post-erasure extension points (issue #37): every {@link ErasureListener} bean and the context's
+     * {@link ApplicationEventPublisher}, so an event-sourced / CQRS consumer can rebuild a projection
+     * after a forgettable-payload reference is erased (ADR-0010). No listener registered = no-op.
+     */
     @Bean
     @ConditionalOnMissingBean
-    public ErasureService gdprErasureService(ObjectProvider<ErasureHandler> handlers) {
-        List<ErasureHandler> resolved = handlers.orderedStream().toList();
-        return new ErasureService(resolved.isEmpty() ? Collections.emptyList() : resolved);
+    public ErasureService gdprErasureService(
+            ObjectProvider<ErasureHandler> handlers,
+            ObjectProvider<ErasureListener> listeners,
+            ApplicationEventPublisher eventPublisher) {
+        List<ErasureHandler> resolvedHandlers = handlers.orderedStream().toList();
+        List<ErasureListener> resolvedListeners = listeners.orderedStream().toList();
+        return new ErasureService(
+                resolvedHandlers.isEmpty() ? Collections.emptyList() : resolvedHandlers,
+                resolvedListeners,
+                eventPublisher);
     }
 
     /**

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureListener.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureListener.java
@@ -1,0 +1,36 @@
+package com.iambilotta.gdpr.starter.erasure;
+
+/**
+ * Post-erasure extension point (issue #37). Implement and register as a Spring bean to react after a
+ * subject's right-to-erasure (Art. 17) has been honoured by every {@link ErasureHandler}.
+ *
+ * <p>The motivating case is the forgettable-payload pattern (ADR-0010): once
+ * {@code ErasureService.eraseSubject} runs, a reference the read side still holds (a display name on
+ * a projection, a cached value) now resolves to nothing. A listener is the deterministic signal to
+ * rebuild that projection or invalidate that cache, instead of every adopter inventing their own
+ * polling. It pairs with crypto-shredding (ADR-0009) identically: a dropped key makes the inline
+ * ciphertext unreadable, and the read side must refresh.
+ *
+ * <p>Invoked <strong>once per successful</strong> {@code eraseSubject}, with the assembled
+ * {@link ErasureReport}, <strong>after</strong> all handlers have committed. Zero listeners is a
+ * no-op (backward compatible); several listeners all run.
+ *
+ * <p><strong>Failure semantics.</strong> The erasure already happened by the time a listener runs
+ * (the handlers committed). A listener that throws never un-erases the subject. The service still
+ * invokes the remaining listeners, then surfaces the failure as an {@link ErasureListenerException}
+ * (logged, not swallowed), so a broken downstream rebuild is visible rather than silent. Make a
+ * listener idempotent: a rebuild may be retried.
+ *
+ * <p>An adopter who prefers Spring's eventing can instead listen for {@link SubjectErasedEvent} via
+ * {@code @EventListener}; the service publishes that event on the same boundary when an
+ * {@code ApplicationEventPublisher} is available (the starter wires one).
+ */
+@FunctionalInterface
+public interface ErasureListener {
+
+    /**
+     * React to a completed erasure. Called once per successful {@code eraseSubject}, after every
+     * handler committed, with the per-type affected counts.
+     */
+    void onSubjectErased(ErasureReport report);
+}

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerException.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerException.java
@@ -1,0 +1,24 @@
+package com.iambilotta.gdpr.starter.erasure;
+
+/**
+ * Thrown by {@link ErasureService} when one or more {@link ErasureListener}s failed after a
+ * subject's erasure had already been honoured by the handlers. The erasure itself stands (the
+ * handlers committed before any listener ran): this exception surfaces a broken downstream reaction
+ * (e.g. a projection rebuild that failed), it never means the subject was un-erased. The first
+ * listener failure is the {@link Throwable#getCause() cause}; later failures are suppressed
+ * exceptions.
+ */
+public class ErasureListenerException extends RuntimeException {
+
+    private final String subjectId;
+
+    public ErasureListenerException(String subjectId, Throwable cause) {
+        super("erasure of subject '" + subjectId + "' completed, but a post-erasure listener failed; "
+                + "the subject is erased, the downstream reaction is not (rebuild/invalidate it)", cause);
+        this.subjectId = subjectId;
+    }
+
+    public String subjectId() {
+        return subjectId;
+    }
+}

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureService.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/ErasureService.java
@@ -1,5 +1,6 @@
 package com.iambilotta.gdpr.starter.erasure;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -8,21 +9,44 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 
 /**
  * Orchestrates the right-to-erasure flow (Art. 17). Iterates registered {@link ErasureHandler}
  * beans in order and reports affected counts per entity type.
+ *
+ * <p>After the report is assembled (every handler committed), it notifies the post-erasure
+ * extension points (issue #37): each registered {@link ErasureListener} is invoked once with the
+ * report and, when an {@link ApplicationEventPublisher} is present, a {@link SubjectErasedEvent} is
+ * published. This is the deterministic signal an event-sourced / CQRS consumer needs to rebuild a
+ * projection that resolved a now-dangling forgettable-payload reference (ADR-0010). Both paths are
+ * optional and backward compatible: with no listener and no publisher this is a no-op.
  */
 public class ErasureService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ErasureService.class);
 
     private final List<ErasureHandler> handlers;
+    private final List<ErasureListener> listeners;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ErasureService(List<ErasureHandler> handlers) {
+        this(handlers, List.of(), null);
+    }
+
+    public ErasureService(List<ErasureHandler> handlers, List<ErasureListener> listeners) {
+        this(handlers, listeners, null);
+    }
+
+    public ErasureService(
+            List<ErasureHandler> handlers,
+            List<ErasureListener> listeners,
+            ApplicationEventPublisher eventPublisher) {
         List<ErasureHandler> sorted = new ArrayList<>(handlers);
         sorted.sort(Comparator.comparingInt(ErasureHandler::order));
         this.handlers = List.copyOf(sorted);
+        this.listeners = List.copyOf(listeners);
+        this.eventPublisher = eventPublisher;
     }
 
     public ErasureReport eraseSubject(String subjectId) {
@@ -42,7 +66,41 @@ public class ErasureService {
                     affected
             );
         }
-        return new ErasureReport(subjectId, affectedByType);
+        ErasureReport report = new ErasureReport(subjectId, affectedByType);
+        notifyAfterErasure(report);
+        return report;
+    }
+
+    /**
+     * Fires the post-erasure extension points once the erasure has committed. The handlers already
+     * ran, so a listener fault never un-erases the subject: every listener still runs, then the first
+     * failure is surfaced as an {@link ErasureListenerException} (logged, never swallowed).
+     */
+    private void notifyAfterErasure(ErasureReport report) {
+        if (eventPublisher != null) {
+            eventPublisher.publishEvent(
+                    new SubjectErasedEvent(report.subjectId(), report.affectedByType(), Instant.now()));
+        }
+        ErasureListenerException surfaced = null;
+        for (ErasureListener listener : listeners) {
+            try {
+                listener.onSubjectErased(report);
+            } catch (RuntimeException ex) {
+                LOG.error(
+                        "gdpr_erasure_listener_failed subject={} listener={}",
+                        report.subjectId(),
+                        listener.getClass().getName(),
+                        ex);
+                if (surfaced == null) {
+                    surfaced = new ErasureListenerException(report.subjectId(), ex);
+                } else {
+                    surfaced.addSuppressed(ex);
+                }
+            }
+        }
+        if (surfaced != null) {
+            throw surfaced;
+        }
     }
 
     public List<String> registeredTypes() {

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/SubjectErasedEvent.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/SubjectErasedEvent.java
@@ -1,0 +1,45 @@
+package com.iambilotta.gdpr.starter.erasure;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published by {@link ErasureService} once a subject's right-to-erasure (Art. 17) has been honoured
+ * by every {@link ErasureHandler} (issue #37). The Spring-native counterpart of the
+ * {@link ErasureListener} SPI: an adopter can react with {@code @EventListener(SubjectErasedEvent.class)}
+ * instead of implementing the SPI, the typical hook for an event-sourced / CQRS consumer to rebuild a
+ * projection that resolved a now-dangling forgettable-payload reference (ADR-0010).
+ *
+ * <p>The event source is the {@code subjectId}; {@link #affectedByType()} mirrors the
+ * {@link ErasureReport} (entity FQN to affected count) and {@link #erasedAt()} is when the report was
+ * assembled. Published only when an {@code ApplicationEventPublisher} is available; the SPI path needs
+ * no Spring context.
+ */
+public class SubjectErasedEvent extends ApplicationEvent {
+
+    private final Map<String, Integer> affectedByType;
+    private final Instant erasedAt;
+
+    public SubjectErasedEvent(String subjectId, Map<String, Integer> affectedByType, Instant erasedAt) {
+        super(subjectId);
+        this.affectedByType = Map.copyOf(affectedByType);
+        this.erasedAt = erasedAt;
+    }
+
+    /** The erased subject (also the {@link #getSource() event source}). */
+    public String subjectId() {
+        return (String) getSource();
+    }
+
+    /** Per-type affected counts, mirroring the {@link ErasureReport}. */
+    public Map<String, Integer> affectedByType() {
+        return affectedByType;
+    }
+
+    /** When the erasure report was assembled. */
+    public Instant erasedAt() {
+        return erasedAt;
+    }
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfigurationTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfigurationTest.java
@@ -98,6 +98,46 @@ class GdprAutoConfigurationTest {
                 com.iambilotta.gdpr.starter.access.AccessExportService.class));
     }
 
+    /**
+     * @spec.given the GDPR autoconfiguration plus a registered ErasureListener and an
+     *             @EventListener for SubjectErasedEvent
+     * @spec.when  the wired ErasureService erases a subject
+     * @spec.then  both the SPI listener and the @EventListener fire once with the subject (issue #37,
+     *             the post-erasure hook for event-sourced/CQRS rebuilds)
+     * @spec.us    REQ-GDPR-023
+     */
+    @Test
+    void wiresPostErasureListenerAndPublishesSubjectErasedEvent() {
+        runner
+                .withUserConfiguration(PostErasureConfig.class)
+                .run(ctx -> {
+                    com.iambilotta.gdpr.starter.erasure.ErasureService service =
+                            ctx.getBean(com.iambilotta.gdpr.starter.erasure.ErasureService.class);
+                    service.eraseSubject("alice-1");
+
+                    PostErasureConfig config = ctx.getBean(PostErasureConfig.class);
+                    assertThat(config.listenerSubjects).containsExactly("alice-1");
+                    assertThat(config.eventSubjects).containsExactly("alice-1");
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class PostErasureConfig {
+
+        final java.util.List<String> listenerSubjects = new java.util.ArrayList<>();
+        final java.util.List<String> eventSubjects = new java.util.ArrayList<>();
+
+        @Bean
+        com.iambilotta.gdpr.starter.erasure.ErasureListener captureListener() {
+            return report -> listenerSubjects.add(report.subjectId());
+        }
+
+        @org.springframework.context.event.EventListener
+        void onErased(com.iambilotta.gdpr.starter.erasure.SubjectErasedEvent event) {
+            eventSubjects.add(event.subjectId());
+        }
+    }
+
     @Configuration(proxyBeanMethods = false)
     static class CustomSinkConfig {
 

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/ErasureListenerTest.java
@@ -1,0 +1,127 @@
+package com.iambilotta.gdpr.starter.erasure;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.iambilotta.gdpr.annotations.GdprErasable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Specification for the post-erasure SPI (issue #37): after {@link ErasureService#eraseSubject}
+ * assembles its report, every registered {@link ErasureListener} is invoked exactly once with that
+ * report, so event-sourced / CQRS consumers can rebuild projections or invalidate caches that held
+ * a now-dangling forgettable-payload reference (ADR-0010). Backward compatible: with no listener it
+ * is a no-op.
+ */
+class ErasureListenerTest {
+
+    static class Customer {}
+
+    /**
+     * @spec.given an ErasureService with one registered ErasureListener
+     * @spec.when  a subject is erased
+     * @spec.then  the listener is invoked exactly once with the assembled report
+     * @spec.us    REQ-GDPR-023
+     */
+    @Test
+    void invokesTheListenerOnceWithTheReportAfterErasure() {
+        CapturingListener listener = new CapturingListener();
+        ErasureService service = new ErasureService(
+                List.of(new FakeHandler(Customer.class, 100, 2)),
+                List.of(listener));
+
+        ErasureReport report = service.eraseSubject("alice-1");
+
+        assertThat(listener.received).hasSize(1);
+        ErasureReport seen = listener.received.get(0);
+        assertThat(seen).isSameAs(report);
+        assertThat(seen.subjectId()).isEqualTo("alice-1");
+        assertThat(seen.affectedByType()).containsEntry(Customer.class.getName(), 2);
+    }
+
+    /**
+     * @spec.given an ErasureService with no listener registered (the legacy constructor)
+     * @spec.when  a subject is erased
+     * @spec.then  the erasure still succeeds and returns its report (backward compatible no-op)
+     * @spec.us    REQ-GDPR-023
+     */
+    @Test
+    void isANoOpAndBackwardCompatibleWhenNoListenerIsRegistered() {
+        ErasureService service = new ErasureService(List.of(new FakeHandler(Customer.class, 100, 1)));
+
+        ErasureReport report = service.eraseSubject("alice-1");
+
+        assertThat(report.totalAffected()).isEqualTo(1);
+    }
+
+    /**
+     * @spec.given an ErasureService with several listeners, one of which throws
+     * @spec.when  a subject is erased
+     * @spec.then  the failure is surfaced (not swallowed) and the other listeners still ran: the
+     *             erasure itself already happened, a listener fault never silently un-erases it
+     * @spec.us    REQ-GDPR-023
+     */
+    @Test
+    void surfacesAListenerFailureWithoutSwallowingOrUnErasing() {
+        CapturingListener before = new CapturingListener();
+        ErasureListener boom = report -> {
+            throw new IllegalStateException("downstream rebuild failed");
+        };
+        CapturingListener after = new CapturingListener();
+        ErasureService service = new ErasureService(
+                List.of(new FakeHandler(Customer.class, 100, 1)),
+                List.of(before, boom, after));
+
+        assertThatThrownBy(() -> service.eraseSubject("alice-1"))
+                .isInstanceOf(ErasureListenerException.class)
+                .hasMessageContaining("alice-1");
+
+        assertThat(before.received).hasSize(1); // ran before the faulty one
+        assertThat(after.received).hasSize(1); // a faulty listener does not block the others
+    }
+
+    private static final class CapturingListener implements ErasureListener {
+        private final List<ErasureReport> received = new ArrayList<>();
+
+        @Override
+        public void onSubjectErased(ErasureReport report) {
+            received.add(report);
+        }
+    }
+
+    private static final class FakeHandler implements ErasureHandler {
+        private final Class<?> type;
+        private final int order;
+        private final int affected;
+
+        FakeHandler(Class<?> type, int order, int affected) {
+            this.type = type;
+            this.order = order;
+            this.affected = affected;
+        }
+
+        @Override
+        public Class<?> entityType() {
+            return type;
+        }
+
+        @Override
+        public GdprErasable.Strategy strategy() {
+            return GdprErasable.Strategy.DELETE;
+        }
+
+        @Override
+        public int erase(String subjectId) {
+            return affected;
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+}


### PR DESCRIPTION
Closes #37.

## What

`ErasureService.eraseSubject` had no post-erasure extension point. After a forgettable-payload erasure (ADR-0010) the events are intact but a referenced PII payload is gone, so downstream read models / projections that resolved that reference must rebuild, invalidate a cache, or re-render the now-opaque ref. There was no signal short of polling.

This adds two equivalent hooks, both fired **once per successful** `eraseSubject`, **after** the handlers commit:

- **`ErasureListener` (SPI)** | `onSubjectErased(ErasureReport)`, zero or more beans, no Spring context required.
- **`SubjectErasedEvent`** | a Spring `ApplicationEvent` for `@EventListener` consumers, published when an `ApplicationEventPublisher` is available.

`GdprAutoConfiguration` wires every `ErasureListener` bean and the context publisher into the service.

## Design

- **Backward compatible.** The legacy `ErasureService(List<ErasureHandler>)` constructor is preserved; two new constructors add the listeners and (optionally) the publisher. With no listener and no publisher the notification is a no-op, so existing adopters are unaffected.
- **Failure semantics (acceptance bullet 3).** The handlers have already committed before any listener runs, so a listener that throws never un-erases the subject. The remaining listeners still run; the first failure is surfaced as an `ErasureListenerException` (logged via SLF4J, never swallowed), later failures attach as suppressed exceptions. Surfacing beats silent logging: a broken downstream rebuild must be visible.
- Pairs with ADR-0009 / ADR-0010 as the issue asks; documented as the integration point for CQRS/event-sourced rebuilds.

## Evidence (spec -> test -> green)

- `ErasureListenerTest`: invoked-once-with-the-report; no-op + backward-compatible with no listener; a faulty listener is surfaced without swallowing or un-erasing.
- `GdprAutoConfigurationTest#wiresPostErasureListenerAndPublishesSubjectErasedEvent`: both the SPI listener and an `@EventListener(SubjectErasedEvent.class)` fire once through the wired service.
- New requirement **REQ-GDPR-023** in `docs/requirements/gdpr.requirements.md` (EARS + Gherkin + trace-to), README "React after erasure" section, CHANGELOG entry.
- tracegate catalog regenerated (`make requirements`); drift-gate green.

## Local gate

`mvn -B -Dspring-gdpr.it=true clean verify` -> BUILD SUCCESS (all modules, incl. Postgres Testcontainers IT). `tracegate . --check` -> exit 0.

Nothing merged; for your review.