### PR TITLE
Declarative crypto-shredding / forgettable erasure: auto-wire from @GdprErasable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ by area: **Annotations**, **Runtime**, **Build-time**, **DX**, **Migrations**,
 ### Added
 - **Annotations:** `@GdprPersonalData.storage` axis (`INLINE` default, `FORGETTABLE_PAYLOAD`),
   declaring a field's value as externalised. Backward-compatible (default `INLINE`).
+- **Annotations:** `@GdprErasable.Strategy` gains `FORGETTABLE` and `CRYPTO_SHRED`
+  ([#36](https://github.com/iambilotta/spring-gdpr/issues/36)). Declaring either auto-wires the
+  matching append-only-safe `ErasureHandler` (no hand config); `DELETE` / `ANONYMIZE` /
+  `PSEUDONYMIZE` are unchanged. Additive and backward-compatible.
+- **Runtime:** declarative append-only-safe erasure ([#36](https://github.com/iambilotta/spring-gdpr/issues/36)):
+  `GdprErasableScannerRegistrar` scans the application packages for `@GdprErasable(strategy =
+  FORGETTABLE | CRYPTO_SHRED)` types and registers a `ForgettablePayloadErasureHandler` /
+  `CryptoShreddingErasureHandler` per type, so `DELETE /gdpr/erasure/{subjectId}` routes them through
+  the existing machinery (ADR-0009 / ADR-0010) with zero `@Configuration`. The starter contributes the
+  default `SubjectKeyStore` / `ForgettablePayloadStore` / `ForgettablePayloadResolver` beans (JDBC when
+  a `DataSource` is present, in-memory dev/test fallback otherwise), each `@ConditionalOnMissingBean`
+  and overridable. The chosen strategy is named in the generated DPIA.
 - **Runtime:** the **forgettable-payload** erasure mechanism, now the **primary** personal-data
   erasure pattern (ADR-0010): `ForgettablePayloadStore` SPI + `JdbcForgettablePayloadStore` /
   `InMemoryForgettablePayloadStore`, `ForgettablePayloadReference` (URN-addressable),

--- a/README.md
+++ b/README.md
@@ -303,6 +303,20 @@ It is the secondary path on purpose. Encryption with a separately-held key is, i
 
 When a subject's data is split across both paths, register both handlers (the erasure orchestration runs every handler) or wrap them in a `CompositeSubjectErasureHandler`, which erases across both as one unit and sums the affected counts so neither path is forgotten.
 
+### Declarative: skip the wiring
+
+You do not have to hand-wire the handler at all. Declare the strategy on the type and the starter wires the matching handler for you:
+
+```java
+@GdprErasable(strategy = Strategy.FORGETTABLE)              // -> ForgettablePayloadErasureHandler, auto-wired
+record CustomerSnapshot(String subjectId, ForgettablePayloadReference fullName) {}
+
+@GdprErasable(strategy = Strategy.CRYPTO_SHRED, order = 20) // -> CryptoShreddingErasureHandler, auto-wired
+record SignedAgreementEvent(String subjectId, byte[] encryptedTerms) {}
+```
+
+The starter scans your application packages for `@GdprErasable` types whose strategy is `FORGETTABLE` or `CRYPTO_SHRED` and registers one handler per type, so `DELETE /gdpr/erasure/{subjectId}` routes them through the existing machinery with **zero** `@Configuration`. It also contributes the backing store beans (`ForgettablePayloadStore` + `ForgettablePayloadResolver`, or `SubjectKeyStore`): JDBC when a `DataSource` is present (apply migration `V3` / `V2`), in-memory otherwise (dev/test only, logged). Every contributed bean is `@ConditionalOnMissingBean`, so declaring your own (a KMS-backed `SubjectKeyStore`, a PII-vault `ForgettablePayloadStore`) overrides it. The declared `order()` flows to the handler for FK-safe sequencing, and the strategy is named in the generated DPIA. `DELETE` / `ANONYMIZE` / `PSEUDONYMIZE` are untouched: they stay your own `ErasureHandler` (the library cannot know how to delete an arbitrary store, [ADR-0004](docs/adr/0004-erasure-handler-orchestration.md)).
+
 ### React after erasure (event-sourced / CQRS rebuilds)
 
 The forgettable-payload pattern leaves the read side with a reference that now resolves to nothing (the same way a crypto-shred drop makes inline ciphertext unreadable). Read models that resolved that reference (a display name on a projection, a cached value) must heal: rebuild the projection, invalidate the cache, re-render the now-opaque ref. After `ErasureService.eraseSubject` honours the request, the library gives you a deterministic signal so you do not poll. Two equivalent hooks, both fire once per successful erasure, after the handlers committed:
@@ -330,7 +344,7 @@ The erasure has already committed by the time a listener runs, so a listener tha
 | `@GdprDataSubjects` | type | Lists data-subject categories | ROPA "data subjects" column |
 | `@GdprLegalBasis` | type, method | Lawful basis (Article 6 / 9 / 10). Build warns if missing on a ROPA record | ROPA "legal basis" column |
 | `@GdprRetention` | type | Retention period + strategy (delete / anonymize / pseudonymize) | ROPA + retention sweep |
-| `@GdprErasable` | type | Right-to-erasure participation, FK-safe ordering | DPIA + erasure flow |
+| `@GdprErasable` | type | Right-to-erasure participation, FK-safe ordering. `strategy = FORGETTABLE` / `CRYPTO_SHRED` auto-wires the library's handler; `DELETE` / `ANONYMIZE` / `PSEUDONYMIZE` stay your own | DPIA + erasure flow |
 
 Article 9 special categories (health, biometric) and Article 10 (criminal convictions) compose: `specialBasis` / `criminalBasis` on `@GdprLegalBasis` produce a composite reference like `6(1)(b) + 9(2)(h)` in the audit row.
 

--- a/docs/requirements/gdpr.requirements.md
+++ b/docs/requirements/gdpr.requirements.md
@@ -317,6 +317,31 @@ And a failing listener is surfaced (not swallowed) while the subject stays erase
 And with no listener registered the erasure still succeeds (no-op)
 ```
 
+### REQ-GDPR-024 | Declarative append-only-safe erasure (auto-wire the crypto / forgettable handler)
+- categoria: funzionale
+- priorità: S
+- fonte: GDPR Art.17; DX gap (a real Axon consumer hand-wired the forgettable store because there was no first-class strategy); issue #36
+- rationale: the crypto-shredding (REQ-GDPR-016, ADR-0009) and forgettable-payload (REQ-GDPR-022, ADR-0010) machinery existed, but `@GdprErasable.Strategy` was only `{DELETE, ANONYMIZE, PSEUDONYMIZE}`, so a type erased by an append-only-safe path could not declare it and the adopter had to hand-wire the handler in a `@Configuration`. The annotation set was not the single honest record of how each type is erased
+- trace-to: `implementato` — `GdprErasable.Strategy` gains `FORGETTABLE` + `CRYPTO_SHRED`; `GdprErasableScannerRegistrar` (an `ImportBeanDefinitionRegistrar`) scans the auto-config base packages and registers one `ForgettablePayloadErasureHandler` / `CryptoShreddingErasureHandler` per declaring type, collaborators wired by type; `GdprAutoConfiguration.ErasureStrategyConfig` contributes the default `SubjectKeyStore` / `ForgettablePayloadStore` / `ForgettablePayloadResolver` beans (`@ConditionalOnMissingBean`, JDBC-or-in-memory fallback); the DPIA names the strategy via the existing `ann.strategy().name()`. `DeclarativeErasureWiringTest` (auto-wires the crypto handler; auto-wires the forgettable handler with its order; DELETE is NOT auto-wired; in-memory store fallbacks; the store beans are overridable)
+- depends-on: REQ-GDPR-016, REQ-GDPR-022
+- stato: implementato
+
+WHEN a type declares `@GdprErasable(strategy = CRYPTO_SHRED)` or `@GdprErasable(strategy = FORGETTABLE)`,
+the system SHALL route that type's right-to-erasure through the matching append-only-safe handler with
+no manual bean wiring (the starter contributes and auto-wires the handler + its backing store,
+overridable), SHALL preserve the append-only invariant (no event mutated/deleted; only the key dropped
+or the external row deleted), and SHALL name the chosen strategy in the generated DPIA. The legacy
+strategies (DELETE / ANONYMIZE / PSEUDONYMIZE) SHALL remain the adopter's own `ErasureHandler`.
+
+```gherkin
+Given a type annotated @GdprErasable(strategy = CRYPTO_SHRED or FORGETTABLE) and no hand-wired handler
+When the application context starts
+Then a CryptoShreddingErasureHandler or ForgettablePayloadErasureHandler is auto-wired for that type
+And the DELETE /gdpr/erasure/{subjectId} flow runs it through the existing machinery
+And the generated DPIA names the strategy
+And a type annotated with DELETE/ANONYMIZE/PSEUDONYMIZE gets no library handler (it stays the adopter's)
+```
+
 ### REQ-GDPR-018 | Structured-log PII redaction (Art.5(1)(f))
 - categoria: qos-constraint
 - priorità: S
@@ -379,3 +404,4 @@ not ready in this repo.
 - 2026-06-08 | REQ-GDPR-016, REQ-GDPR-017 | proposto -> implementato | crypto-shredding shipped under ADR-0009 (accepted): per-subject AES-256-GCM key store (`SubjectKeyStore` SPI + JDBC default, `gdpr_subject_key`/V2), `AesGcmCryptoShredder`, `CryptoShreddingErasureHandler` (drop-the-key + audit fact); `CryptoShreddingErasureTest` un-`@Disabled` (4 GREEN) plus `AesGcmCryptoShredderTest`/`JdbcSubjectKeyStoreTest`
 - 2026-06-08 | REQ-GDPR-022 | created -> implementato | forgettable-payload external store made the PRIMARY personal-data erasure path (ADR-0010), crypto-shredding repositioned as the exception (pseudonymisation vs anonymisation, Recital 26 / EDPB 01/2025): `ForgettablePayloadStore` SPI + `JdbcForgettablePayloadStore` (`gdpr_forgettable_payload`/V3) + `InMemoryForgettablePayloadStore`, `ForgettablePayloadReference`, `ForgettablePayloadResolver` (fail-closed), `ForgettablePayloadErasureHandler` (DELETE + audit fact), `CompositeSubjectErasureHandler` (erase across both), `@GdprPersonalData.storage` axis; 27 new GREEN tests across 7 classes
 - 2026-06-17 | REQ-GDPR-023 | created -> implementato | post-erasure SPI (issue #37): `ErasureListener` SPI + `SubjectErasedEvent` fired once by `ErasureService.eraseSubject` after the handlers commit, the hook for event-sourced / CQRS consumers to rebuild a projection that held a now-dangling forgettable-payload reference; wired by `GdprAutoConfiguration` (every listener bean + the context `ApplicationEventPublisher`), failure surfaced as `ErasureListenerException` without un-erasing, no-op + backward-compatible with no listener; `ErasureListenerTest` (3) + `GdprAutoConfigurationTest#wiresPostErasureListenerAndPublishesSubjectErasedEvent`
+- 2026-06-17 | REQ-GDPR-024 | created -> implementato | declarative append-only-safe erasure (issue #36): `@GdprErasable.Strategy` gains `FORGETTABLE` + `CRYPTO_SHRED`; `GdprErasableScannerRegistrar` scans the app packages and auto-wires the matching library `ErasureHandler` per declaring type, `GdprAutoConfiguration.ErasureStrategyConfig` contributes the overridable `SubjectKeyStore`/`ForgettablePayloadStore`/`ForgettablePayloadResolver` beans (JDBC-or-in-memory); DELETE/ANONYMIZE/PSEUDONYMIZE stay the adopter's; DPIA names the strategy via the existing rendering; `DeclarativeErasureWiringTest` (6 GREEN)

--- a/spring-gdpr-annotations/src/main/java/com/iambilotta/gdpr/annotations/GdprErasable.java
+++ b/spring-gdpr-annotations/src/main/java/com/iambilotta/gdpr/annotations/GdprErasable.java
@@ -44,6 +44,31 @@ public @interface GdprErasable {
     enum Strategy {
         DELETE,
         ANONYMIZE,
-        PSEUDONYMIZE
+        PSEUDONYMIZE,
+
+        /**
+         * Forgettable-payload erasure (the PRIMARY append-only-safe pattern, ADR-0010): the type's
+         * personal data lives in an external {@code ForgettablePayloadStore}, and erasure is an actual
+         * {@code DELETE} of those rows while the immutable carrier keeps only a dangling reference.
+         *
+         * <p>Declaring it auto-wires a {@code ForgettablePayloadErasureHandler} for this type with no
+         * hand config (the starter contributes the store + resolver beans, overridable). Prefer this
+         * over {@link #CRYPTO_SHRED} for personal data: deleting the value is anonymisation, whereas a
+         * dropped key leaves ciphertext that is, in law, still pseudonymised personal data (Recital 26,
+         * EDPB 01/2025).
+         */
+        FORGETTABLE,
+
+        /**
+         * Crypto-shredding erasure (the append-only-safe EXCEPTION, ADR-0009): the type's personal data
+         * is encrypted inline with a per-subject key, and erasure is the drop of that key, after which
+         * the byte-immutable ciphertext is permanently unreadable while no event is touched.
+         *
+         * <p>Declaring it auto-wires a {@code CryptoShreddingErasureHandler} for this type with no hand
+         * config (the starter contributes the key store + shredder beans, overridable). Use only where
+         * an immutable event must legally carry the value inline and externalising it via
+         * {@link #FORGETTABLE} is not acceptable (a signed/notarised event, an integrity requirement).
+         */
+        CRYPTO_SHRED
     }
 }

--- a/spring-gdpr-starter/_generated/modules.md
+++ b/spring-gdpr-starter/_generated/modules.md
@@ -13,7 +13,7 @@ Auto-generated. Modulith convention: each top-level package under `it.housetrees
 | `(root)` | 1 | 1 | _(none)_ | _(none)_ |
 | `access` | 5 | 1 | _(none)_ | `jdbc` |
 | `audit` | 9 | 1 | _(none)_ | _(none)_ |
-| `autoconfig` | 1 | 1 | _(none)_ | `access`, `audit`, `erasure`, `retention`, `web` |
+| `autoconfig` | 2 | 1 | _(none)_ | `access`, `audit`, `erasure`, `retention`, `web` |
 | `erasure` | 21 | 3 | _(none)_ | `audit`, `jdbc` |
 | `jdbc` | 1 | 1 | _(none)_ | _(none)_ |
 | `logging` | 2 | 1 | _(none)_ | _(none)_ |
@@ -78,7 +78,7 @@ component "web"
 
 ### `autoconfig`
 
-- **Files**: 1
+- **Files**: 2
 - **Sub-packages** (1):
   - `autoconfig`
 - **Exposed API**: _(only the top-level package; no inner exports)_

--- a/spring-gdpr-starter/_generated/requirements-by-us.md
+++ b/spring-gdpr-starter/_generated/requirements-by-us.md
@@ -4,8 +4,8 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
 
 ## Coverage
 
-- Total tests scanned: **101**
-- Tests linked to a User Story: **66**
+- Total tests scanned: **107**
+- Tests linked to a User Story: **72**
 - Tests without `@spec.us` (implementation detail): **35**
 - User Stories declared in PRODUCT.md: **0**
 - User Stories with at least one linked test: **0**
@@ -131,6 +131,21 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
   - **Then**: the erasure still succeeds and returns its report (backward compatible no-op)
 - `FR-erasure.ErasureListener#surfacesAListenerFailureWithoutSwallowingOrUnErasing`
   - **Then**: the failure is surfaced (not swallowed) and the other listeners still ran: the erasure itself already happened, a listener fault never silently un-erases it
+
+## `REQ-GDPR-024`  _(unknown to PRODUCT.md)_
+
+- `FR-autoconfig.DeclarativeErasureWiring#autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType`
+  - **Then**: a CryptoShreddingErasureHandler for that type is auto-wired and visible to the ErasureService (issue #36, the declarative bridge to the ADR-0009 machinery)
+- `FR-autoconfig.DeclarativeErasureWiring#autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder`
+  - **Then**: a ForgettablePayloadErasureHandler is auto-wired with the declared order and is visible to the ErasureService (issue #36, the ADR-0010 primary path, declarative)
+- `FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryForgettableStoreFallbackWhenNoDataSourceIsPresent`
+  - **Then**: an in-memory ForgettablePayloadStore is contributed as the dev/test fallback
+- `FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryKeyStoreFallbackWhenNoDataSourceIsPresent`
+  - **Then**: an in-memory SubjectKeyStore is contributed (dev/test fallback) and the wired handler runs end to end against it
+- `FR-autoconfig.DeclarativeErasureWiring#doesNotAutoWireAHandlerForTheLegacyDeleteStrategy`
+  - **Then**: no library handler is auto-wired for it: DELETE/ANONYMIZE/PSEUDONYMIZE stay the adopter's ErasureHandler (ADR-0004), only the append-only-safe strategies are wired
+- `FR-autoconfig.DeclarativeErasureWiring#theDefaultStoreBeansAreOverridable`
+  - **Then**: the adopter's store wins (the default is @ConditionalOnMissingBean, overridable)
 
 ## `US-DX-001-honest-erasure-error-contract`  _(unknown to PRODUCT.md)_
 

--- a/spring-gdpr-starter/_generated/requirements.json
+++ b/spring-gdpr-starter/_generated/requirements.json
@@ -5,10 +5,10 @@
   },
   "label": "spring-gdpr-starter",
   "coverage": {
-    "total": 101,
-    "with_complete_spec": 66,
+    "total": 107,
+    "with_complete_spec": 72,
     "by_category": {
-      "FR": 101
+      "FR": 107
     }
   },
   "requirements": [
@@ -520,6 +520,108 @@
         "us": "",
         "ac": "",
         "complete": false
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "a type annotated @GdprErasable(strategy = CRYPTO_SHRED) and no hand-wired handler",
+        "when": "the context starts with that type's package as the scanned base",
+        "then": "a CryptoShreddingErasureHandler for that type is auto-wired and visible to the ErasureService (issue #36, the declarative bridge to the ADR-0009 machinery)",
+        "adr": "ADR-0009",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "a type annotated @GdprErasable(strategy = FORGETTABLE, order = 30)",
+        "when": "the context starts with that type's package as the scanned base",
+        "then": "a ForgettablePayloadErasureHandler is auto-wired with the declared order and is visible to the ErasureService (issue #36, the ADR-0010 primary path, declarative)",
+        "adr": "ADR-0010",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryForgettableStoreFallbackWhenNoDataSourceIsPresent",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "contributesAnInMemoryForgettableStoreFallbackWhenNoDataSourceIsPresent",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "a FORGETTABLE type with no DataSource",
+        "when": "the context starts",
+        "then": "an in-memory ForgettablePayloadStore is contributed as the dev/test fallback",
+        "adr": "",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryKeyStoreFallbackWhenNoDataSourceIsPresent",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "contributesAnInMemoryKeyStoreFallbackWhenNoDataSourceIsPresent",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "declaring CRYPTO_SHRED with no DataSource on the context",
+        "when": "the context starts",
+        "then": "an in-memory SubjectKeyStore is contributed (dev/test fallback) and the wired handler runs end to end against it",
+        "adr": "",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#doesNotAutoWireAHandlerForTheLegacyDeleteStrategy",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "doesNotAutoWireAHandlerForTheLegacyDeleteStrategy",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "a type annotated with the legacy strategy DELETE (the adopter owns the handler)",
+        "when": "the context starts with that type's package as the scanned base",
+        "then": "no library handler is auto-wired for it: DELETE/ANONYMIZE/PSEUDONYMIZE stay the adopter's ErasureHandler (ADR-0004), only the append-only-safe strategies are wired",
+        "adr": "ADR-0004",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-autoconfig.DeclarativeErasureWiring#theDefaultStoreBeansAreOverridable",
+      "category": "FR",
+      "module": "autoconfig",
+      "unit": "DeclarativeErasureWiring",
+      "method": "theDefaultStoreBeansAreOverridable",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java",
+      "spec": {
+        "given": "an adopter that declares their own SubjectKeyStore bean",
+        "when": "the context starts with a CRYPTO_SHRED type",
+        "then": "the adopter's store wins (the default is @ConditionalOnMissingBean, overridable)",
+        "adr": "",
+        "us": "REQ-GDPR-024",
+        "ac": "",
+        "complete": true
       }
     },
     {

--- a/spring-gdpr-starter/_generated/requirements.md
+++ b/spring-gdpr-starter/_generated/requirements.md
@@ -6,9 +6,9 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 
 ## Coverage
 
-- Total tests scanned: **101**
-- With complete spec javadoc: **66** (65%)
-- FR: 101
+- Total tests scanned: **107**
+- With complete spec javadoc: **72** (67%)
+- FR: 107
 
 ## Module `access`
 
@@ -194,6 +194,57 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 ## Module `autoconfig`
 
 ### Functional Requirements
+
+#### `FR-autoconfig.DeclarativeErasureWiring#autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType`
+
+- **Given**: a type annotated @GdprErasable(strategy = CRYPTO_SHRED) and no hand-wired handler
+- **When**: the context starts with that type's package as the scanned base
+- **Then**: a CryptoShreddingErasureHandler for that type is auto-wired and visible to the ErasureService (issue #36, the declarative bridge to the ADR-0009 machinery)
+- **ADR**: ADR-0009
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
+
+#### `FR-autoconfig.DeclarativeErasureWiring#autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder`
+
+- **Given**: a type annotated @GdprErasable(strategy = FORGETTABLE, order = 30)
+- **When**: the context starts with that type's package as the scanned base
+- **Then**: a ForgettablePayloadErasureHandler is auto-wired with the declared order and is visible to the ErasureService (issue #36, the ADR-0010 primary path, declarative)
+- **ADR**: ADR-0010
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
+
+#### `FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryForgettableStoreFallbackWhenNoDataSourceIsPresent`
+
+- **Given**: a FORGETTABLE type with no DataSource
+- **When**: the context starts
+- **Then**: an in-memory ForgettablePayloadStore is contributed as the dev/test fallback
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
+
+#### `FR-autoconfig.DeclarativeErasureWiring#contributesAnInMemoryKeyStoreFallbackWhenNoDataSourceIsPresent`
+
+- **Given**: declaring CRYPTO_SHRED with no DataSource on the context
+- **When**: the context starts
+- **Then**: an in-memory SubjectKeyStore is contributed (dev/test fallback) and the wired handler runs end to end against it
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
+
+#### `FR-autoconfig.DeclarativeErasureWiring#doesNotAutoWireAHandlerForTheLegacyDeleteStrategy`
+
+- **Given**: a type annotated with the legacy strategy DELETE (the adopter owns the handler)
+- **When**: the context starts with that type's package as the scanned base
+- **Then**: no library handler is auto-wired for it: DELETE/ANONYMIZE/PSEUDONYMIZE stay the adopter's ErasureHandler (ADR-0004), only the append-only-safe strategies are wired
+- **ADR**: ADR-0004
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
+
+#### `FR-autoconfig.DeclarativeErasureWiring#theDefaultStoreBeansAreOverridable`
+
+- **Given**: an adopter that declares their own SubjectKeyStore bean
+- **When**: the context starts with a CRYPTO_SHRED type
+- **Then**: the adopter's store wins (the default is @ConditionalOnMissingBean, overridable)
+- **User Story**: REQ-GDPR-024
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java`
 
 #### `FR-autoconfig.GdprAutoConfiguration#defaultsToSlf4jSinkWhenJdbcDisabled`
 

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import com.iambilotta.gdpr.starter.GdprProperties;
@@ -34,6 +35,13 @@ import com.iambilotta.gdpr.starter.audit.SubjectIdResolver;
 import com.iambilotta.gdpr.starter.erasure.ErasureHandler;
 import com.iambilotta.gdpr.starter.erasure.ErasureListener;
 import com.iambilotta.gdpr.starter.erasure.ErasureService;
+import com.iambilotta.gdpr.starter.erasure.crypto.InMemorySubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.crypto.JdbcSubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.crypto.SubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadResolver;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.InMemoryForgettablePayloadStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.JdbcForgettablePayloadStore;
 import com.iambilotta.gdpr.starter.retention.RetentionScheduler;
 import com.iambilotta.gdpr.starter.retention.RetentionTarget;
 import com.iambilotta.gdpr.starter.web.GdprController;
@@ -153,6 +161,57 @@ public class GdprAutoConfiguration {
             return true;
         } catch (ClassNotFoundException ex) {
             return false;
+        }
+    }
+
+    /**
+     * Declarative append-only-safe erasure (issue #36). Contributes the default store beans for the
+     * two library-owned strategies and imports {@link GdprErasableScannerRegistrar}, which scans the
+     * application packages and auto-wires a {@code CryptoShreddingErasureHandler} /
+     * {@code ForgettablePayloadErasureHandler} per type that declares
+     * {@code @GdprErasable(strategy = CRYPTO_SHRED | FORGETTABLE)}. Each store bean is
+     * {@code @ConditionalOnMissingBean}, so an adopter overrides it (e.g. a KMS-backed key store or a
+     * PII-vault payload store) just by declaring their own.
+     *
+     * <p>The default store is JDBC when a {@link DataSource} and {@code JdbcTemplate} are present, and
+     * an in-memory store otherwise, mirroring the audit-sink fallback so the app starts in dev / tests
+     * without a DB. The in-memory store is logged as not-for-production (keys / values live only in the
+     * heap and vanish on restart, an involuntary erasure of everyone).
+     */
+    @Configuration(proxyBeanMethods = false)
+    @Import(GdprErasableScannerRegistrar.class)
+    public static class ErasureStrategyConfig {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public SubjectKeyStore gdprSubjectKeyStore(ObjectProvider<DataSource> dataSourceProvider) {
+            DataSource dataSource = dataSourceProvider.getIfAvailable();
+            if (isJdbcTemplateOnClasspath() && dataSource != null) {
+                return new JdbcSubjectKeyStore(dataSource);
+            }
+            LOG.warn("No DataSource / spring-jdbc for the crypto-shred key store; using an in-memory "
+                    + "SubjectKeyStore. NOT for production (keys live in the heap and vanish on restart, "
+                    + "an involuntary erasure). Provide a DataSource or a KMS-backed SubjectKeyStore bean.");
+            return new InMemorySubjectKeyStore();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public ForgettablePayloadStore gdprForgettablePayloadStore(ObjectProvider<DataSource> dataSourceProvider) {
+            DataSource dataSource = dataSourceProvider.getIfAvailable();
+            if (isJdbcTemplateOnClasspath() && dataSource != null) {
+                return new JdbcForgettablePayloadStore(dataSource);
+            }
+            LOG.warn("No DataSource / spring-jdbc for the forgettable-payload store; using an in-memory "
+                    + "ForgettablePayloadStore. NOT for production (values live in the heap and vanish on "
+                    + "restart). Provide a DataSource or a vault-backed ForgettablePayloadStore bean.");
+            return new InMemoryForgettablePayloadStore();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public ForgettablePayloadResolver gdprForgettablePayloadResolver(ForgettablePayloadStore store) {
+            return new ForgettablePayloadResolver(store);
         }
     }
 

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprErasableScannerRegistrar.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprErasableScannerRegistrar.java
@@ -1,0 +1,144 @@
+package com.iambilotta.gdpr.starter.autoconfig;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+
+import com.iambilotta.gdpr.annotations.GdprErasable;
+import com.iambilotta.gdpr.starter.audit.ActorResolver;
+import com.iambilotta.gdpr.starter.audit.AuditSink;
+import com.iambilotta.gdpr.starter.erasure.crypto.CryptoShreddingErasureHandler;
+import com.iambilotta.gdpr.starter.erasure.crypto.SubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadErasureHandler;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadStore;
+
+/**
+ * Closes the declarative-erasure DX gap (issue #36): scans the application packages for types
+ * annotated {@link GdprErasable} whose {@link GdprErasable.Strategy strategy} is
+ * {@link GdprErasable.Strategy#CRYPTO_SHRED} or {@link GdprErasable.Strategy#FORGETTABLE}, and
+ * registers the matching {@code ErasureHandler} bean for each, so declaring the annotation routes the
+ * type's right-to-erasure through the existing crypto / forgettable machinery (ADR-0009 / ADR-0010)
+ * with <strong>zero hand-wiring</strong>. The store / key-store beans are contributed (and
+ * overridable) by {@link GdprAutoConfiguration}.
+ *
+ * <p>This is the same scan-and-register pattern Spring Data uses for repositories: an
+ * {@link ImportBeanDefinitionRegistrar} that reads the auto-configuration base packages and adds one
+ * bean definition per discovered type. The handler's collaborators (the store / key store, the
+ * {@code AuditSink}, the {@code ActorResolver}) are wired by type at instantiation, so the scan only
+ * needs the entity {@link Class} and the declared {@link GdprErasable#order()}.
+ *
+ * <p><strong>DELETE / ANONYMIZE / PSEUDONYMIZE are untouched.</strong> They stay the adopter's own
+ * {@code ErasureHandler} (ADR-0004): the library cannot know how to delete an arbitrary store. Only
+ * the two append-only-safe strategies have a reusable library handler to auto-wire.
+ */
+public class GdprErasableScannerRegistrar
+        implements ImportBeanDefinitionRegistrar, BeanFactoryAware, ResourceLoaderAware, EnvironmentAware {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GdprErasableScannerRegistrar.class);
+
+    private BeanFactory beanFactory;
+    private ResourceLoader resourceLoader;
+    private Environment environment;
+
+    @Override
+    public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+        if (!AutoConfigurationPackages.has(beanFactory)) {
+            LOG.debug("No auto-configuration base packages available; skipping @GdprErasable scan.");
+            return;
+        }
+        List<String> basePackages = AutoConfigurationPackages.get(beanFactory);
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false, environment);
+        scanner.setResourceLoader(resourceLoader);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(GdprErasable.class));
+
+        for (String basePackage : basePackages) {
+            for (BeanDefinition candidate : scanner.findCandidateComponents(basePackage)) {
+                registerHandlerFor(candidate.getBeanClassName(), registry);
+            }
+        }
+    }
+
+    private void registerHandlerFor(String className, BeanDefinitionRegistry registry) {
+        Class<?> entityType;
+        try {
+            entityType = Class.forName(className, false, resourceLoader.getClassLoader());
+        } catch (ClassNotFoundException ex) {
+            LOG.warn("Could not load @GdprErasable type {} for auto-wiring; skipping.", className, ex);
+            return;
+        }
+        GdprErasable erasable = entityType.getAnnotation(GdprErasable.class);
+        if (erasable == null) {
+            return;
+        }
+        switch (erasable.strategy()) {
+            case CRYPTO_SHRED -> register(
+                    registry, entityType, erasable.order(), CryptoShreddingErasureHandler.class);
+            case FORGETTABLE -> register(
+                    registry, entityType, erasable.order(), ForgettablePayloadErasureHandler.class);
+            default -> { /* DELETE / ANONYMIZE / PSEUDONYMIZE stay the adopter's own handler (ADR-0004) */ }
+        }
+    }
+
+    /**
+     * Registers one handler bean for the entity type. The store / key store, the audit sink and the
+     * actor resolver are resolved by <strong>type</strong> (so an adopter who overrides any of them
+     * under a different bean name is still picked up); the entity {@link Class} and the
+     * {@link GdprErasable#order()} are constructor values. Skips if a handler bean for this type was
+     * already registered (idempotent across repeated imports).
+     */
+    private void register(
+            BeanDefinitionRegistry registry, Class<?> entityType, int order, Class<?> handlerType) {
+        String beanName = "gdprErasureHandler#" + entityType.getName();
+        if (registry.containsBeanDefinition(beanName)) {
+            return;
+        }
+        Class<?> storeType = handlerType == CryptoShreddingErasureHandler.class
+                ? SubjectKeyStore.class
+                : ForgettablePayloadStore.class;
+        AbstractBeanDefinition definition = BeanDefinitionBuilder
+                .genericBeanDefinition(handlerType)
+                .addConstructorArgValue(new RuntimeBeanReference(storeType))
+                .addConstructorArgValue(new RuntimeBeanReference(AuditSink.class))
+                .addConstructorArgValue(new RuntimeBeanReference(ActorResolver.class))
+                .addConstructorArgValue(entityType)
+                .addConstructorArgValue(order)
+                .getBeanDefinition();
+        registry.registerBeanDefinition(beanName, definition);
+        LOG.debug("Auto-wired {} for @GdprErasable type {} (order={}).",
+                handlerType.getSimpleName(), entityType.getName(), order);
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/DeclarativeErasureWiringTest.java
@@ -1,0 +1,177 @@
+package com.iambilotta.gdpr.starter.autoconfig;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.iambilotta.gdpr.starter.autoconfig.declfixture.crypto.CryptoShreddedEntity;
+import com.iambilotta.gdpr.starter.autoconfig.declfixture.forgettable.ForgettableEntity;
+import com.iambilotta.gdpr.starter.erasure.ErasureService;
+import com.iambilotta.gdpr.starter.erasure.crypto.CryptoShreddingErasureHandler;
+import com.iambilotta.gdpr.starter.erasure.crypto.InMemorySubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.crypto.SubjectKeyStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadErasureHandler;
+import com.iambilotta.gdpr.starter.erasure.forgettable.ForgettablePayloadStore;
+import com.iambilotta.gdpr.starter.erasure.forgettable.InMemoryForgettablePayloadStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Specification for declarative append-only-safe erasure (issue #36): declaring
+ * {@code @GdprErasable(strategy = CRYPTO_SHRED | FORGETTABLE)} on a type, with NO manual bean wiring,
+ * routes that type's right-to-erasure through the existing crypto / forgettable handler (ADR-0009 /
+ * ADR-0010). The store / key-store beans are contributed by the starter and overridable.
+ *
+ * <p>The three fixture types each live in their own package (under {@code declfixture/}) so the
+ * classpath scan rooted at one package finds exactly one type, keeping each assertion isolated.
+ */
+class DeclarativeErasureWiringTest {
+
+    private static final String CRYPTO_PKG = "com.iambilotta.gdpr.starter.autoconfig.declfixture.crypto";
+    private static final String FORGETTABLE_PKG = "com.iambilotta.gdpr.starter.autoconfig.declfixture.forgettable";
+    private static final String LEGACY_PKG = "com.iambilotta.gdpr.starter.autoconfig.declfixture.legacy";
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(GdprAutoConfiguration.class))
+            .withPropertyValues("spring.gdpr.audit.async.enabled=false");
+
+    /**
+     * @spec.given a type annotated @GdprErasable(strategy = CRYPTO_SHRED) and no hand-wired handler
+     * @spec.when  the context starts with that type's package as the scanned base
+     * @spec.then  a CryptoShreddingErasureHandler for that type is auto-wired and visible to the
+     *             ErasureService (issue #36, the declarative bridge to the ADR-0009 machinery)
+     * @spec.adr   ADR-0009
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType() {
+        runner.withUserConfiguration(CryptoScan.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(CryptoShreddingErasureHandler.class);
+            CryptoShreddingErasureHandler handler = ctx.getBean(CryptoShreddingErasureHandler.class);
+            assertThat(handler.entityType()).isEqualTo(CryptoShreddedEntity.class);
+            assertThat(ctx.getBean(ErasureService.class).registeredTypes())
+                    .contains(CryptoShreddedEntity.class.getName());
+        });
+    }
+
+    /**
+     * @spec.given a type annotated @GdprErasable(strategy = FORGETTABLE, order = 30)
+     * @spec.when  the context starts with that type's package as the scanned base
+     * @spec.then  a ForgettablePayloadErasureHandler is auto-wired with the declared order and is
+     *             visible to the ErasureService (issue #36, the ADR-0010 primary path, declarative)
+     * @spec.adr   ADR-0010
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder() {
+        runner.withUserConfiguration(ForgettableScan.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(ForgettablePayloadErasureHandler.class);
+            ForgettablePayloadErasureHandler handler = ctx.getBean(ForgettablePayloadErasureHandler.class);
+            assertThat(handler.entityType()).isEqualTo(ForgettableEntity.class);
+            assertThat(handler.order()).isEqualTo(30);
+            assertThat(ctx.getBean(ErasureService.class).registeredTypes())
+                    .contains(ForgettableEntity.class.getName());
+        });
+    }
+
+    /**
+     * @spec.given a type annotated with the legacy strategy DELETE (the adopter owns the handler)
+     * @spec.when  the context starts with that type's package as the scanned base
+     * @spec.then  no library handler is auto-wired for it: DELETE/ANONYMIZE/PSEUDONYMIZE stay the
+     *             adopter's ErasureHandler (ADR-0004), only the append-only-safe strategies are wired
+     * @spec.adr   ADR-0004
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void doesNotAutoWireAHandlerForTheLegacyDeleteStrategy() {
+        runner.withUserConfiguration(LegacyScan.class).run(ctx -> {
+            assertThat(ctx).doesNotHaveBean(CryptoShreddingErasureHandler.class);
+            assertThat(ctx).doesNotHaveBean(ForgettablePayloadErasureHandler.class);
+        });
+    }
+
+    /**
+     * @spec.given declaring CRYPTO_SHRED with no DataSource on the context
+     * @spec.when  the context starts
+     * @spec.then  an in-memory SubjectKeyStore is contributed (dev/test fallback) and the wired
+     *             handler runs end to end against it
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void contributesAnInMemoryKeyStoreFallbackWhenNoDataSourceIsPresent() {
+        runner.withUserConfiguration(CryptoScan.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(SubjectKeyStore.class);
+            assertThat(ctx.getBean(SubjectKeyStore.class)).isInstanceOf(InMemorySubjectKeyStore.class);
+            int affected = ctx.getBean(CryptoShreddingErasureHandler.class).erase("alice-1");
+            assertThat(affected).isZero(); // no key minted yet, but the path is wired and runs
+        });
+    }
+
+    /**
+     * @spec.given an adopter that declares their own SubjectKeyStore bean
+     * @spec.when  the context starts with a CRYPTO_SHRED type
+     * @spec.then  the adopter's store wins (the default is @ConditionalOnMissingBean, overridable)
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void theDefaultStoreBeansAreOverridable() {
+        runner.withUserConfiguration(CryptoScan.class, CustomKeyStoreConfig.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(SubjectKeyStore.class);
+            assertThat(ctx.getBean(SubjectKeyStore.class)).isSameAs(CustomKeyStoreConfig.CUSTOM);
+        });
+    }
+
+    /**
+     * @spec.given a FORGETTABLE type with no DataSource
+     * @spec.when  the context starts
+     * @spec.then  an in-memory ForgettablePayloadStore is contributed as the dev/test fallback
+     * @spec.us    REQ-GDPR-024
+     */
+    @Test
+    void contributesAnInMemoryForgettableStoreFallbackWhenNoDataSourceIsPresent() {
+        runner.withUserConfiguration(ForgettableScan.class).run(ctx -> {
+            assertThat(ctx).hasSingleBean(ForgettablePayloadStore.class);
+            assertThat(ctx.getBean(ForgettablePayloadStore.class))
+                    .isInstanceOf(InMemoryForgettablePayloadStore.class);
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @AutoConfigurationPackage(basePackages = CRYPTO_PKG)
+    static class CryptoScan {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @AutoConfigurationPackage(basePackages = FORGETTABLE_PKG)
+    static class ForgettableScan {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @AutoConfigurationPackage(basePackages = LEGACY_PKG)
+    static class LegacyScan {
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomKeyStoreConfig {
+        static final SubjectKeyStore CUSTOM = new InMemorySubjectKeyStore();
+
+        @Bean
+        SubjectKeyStore myKmsKeyStore() {
+            return CUSTOM;
+        }
+
+        @Bean
+        DataSource dataSource() {
+            org.h2.jdbcx.JdbcDataSource ds = new org.h2.jdbcx.JdbcDataSource();
+            ds.setURL("jdbc:h2:mem:declarative-override;DB_CLOSE_DELAY=-1");
+            ds.setUser("sa");
+            ds.setPassword("");
+            return ds;
+        }
+    }
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/crypto/CryptoShreddedEntity.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/crypto/CryptoShreddedEntity.java
@@ -1,0 +1,11 @@
+package com.iambilotta.gdpr.starter.autoconfig.declfixture.crypto;
+
+import com.iambilotta.gdpr.annotations.GdprErasable;
+
+/**
+ * Test fixture for declarative crypto-shredding (issue #36). Isolated in its own package so a scan
+ * rooted here finds only the CRYPTO_SHRED type, never the forgettable / legacy fixtures.
+ */
+@GdprErasable(strategy = GdprErasable.Strategy.CRYPTO_SHRED)
+public record CryptoShreddedEntity(String subjectId) {
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/forgettable/ForgettableEntity.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/forgettable/ForgettableEntity.java
@@ -1,0 +1,12 @@
+package com.iambilotta.gdpr.starter.autoconfig.declfixture.forgettable;
+
+import com.iambilotta.gdpr.annotations.GdprErasable;
+
+/**
+ * Test fixture for declarative forgettable-payload erasure (issue #36). Isolated in its own package
+ * so a scan rooted here finds only the FORGETTABLE type. {@code order = 30} pins that the declared
+ * order flows to the auto-wired handler.
+ */
+@GdprErasable(strategy = GdprErasable.Strategy.FORGETTABLE, order = 30)
+public record ForgettableEntity(String subjectId) {
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/legacy/DeleteEntity.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/autoconfig/declfixture/legacy/DeleteEntity.java
@@ -1,0 +1,12 @@
+package com.iambilotta.gdpr.starter.autoconfig.declfixture.legacy;
+
+import com.iambilotta.gdpr.annotations.GdprErasable;
+
+/**
+ * Test fixture for the legacy {@code DELETE} strategy (issue #36). Isolated in its own package so a
+ * scan rooted here finds only this type and proves the scanner does NOT auto-wire a library handler
+ * for DELETE / ANONYMIZE / PSEUDONYMIZE (those stay the adopter's own handler, ADR-0004).
+ */
+@GdprErasable(strategy = GdprErasable.Strategy.DELETE)
+public record DeleteEntity(String subjectId) {
+}


### PR DESCRIPTION
Closes #36.

## What

The crypto-shredding (ADR-0009) and forgettable-payload (ADR-0010) machinery already existed and is correct, but `@GdprErasable.Strategy` was only `{DELETE, ANONYMIZE, PSEUDONYMIZE}`. A type that should be erased by an append-only-safe path could not declare it, so adopters hand-wired the handler + store beans in a `@Configuration` (a real Axon consumer hit exactly this). The mechanism was there; the declarative bridge was not.

This adds the bridge:

1. **`@GdprErasable.Strategy` gains `FORGETTABLE` and `CRYPTO_SHRED`** (additive, backward compatible).
2. **`GdprErasableScannerRegistrar`** | an `ImportBeanDefinitionRegistrar` (the same scan-and-register pattern Spring Data uses for repositories) scans the auto-configuration base packages for `@GdprErasable` types with either strategy and registers a `ForgettablePayloadErasureHandler` / `CryptoShreddingErasureHandler` per type. Collaborators (store/key store, `AuditSink`, `ActorResolver`) are resolved **by type**, so an override under any bean name is still picked up.
3. **`GdprAutoConfiguration.ErasureStrategyConfig`** | contributes the default `SubjectKeyStore` / `ForgettablePayloadStore` / `ForgettablePayloadResolver` beans (JDBC when a `DataSource` is present, in-memory dev/test fallback otherwise, logged as not-for-production). All `@ConditionalOnMissingBean`, so a KMS-backed key store or a PII-vault payload store overrides them.

So `@GdprErasable(strategy = CRYPTO_SHRED)` (or `FORGETTABLE`) on a type, with **zero** hand config, routes its right-to-erasure through the existing handler.

## Acceptance (from the issue)

- [x] Declaring the strategy with no manual wiring routes erasure through the crypto/forgettable handler | `DeclarativeErasureWiringTest#autoWiresACryptoShreddingHandlerForACryptoShredAnnotatedType`, `#autoWiresAForgettablePayloadHandlerForAForgettableAnnotatedTypeWithItsOrder` (asserts the handler is visible to `ErasureService.registeredTypes()`).
- [x] Append-only invariant preserved | the auto-wired handler is the unchanged `CryptoShreddingErasureHandler` (key drop) / `ForgettablePayloadErasureHandler` (external `DELETE`); no event path touched.
- [x] DPIA names the strategy | the processor already renders `ann.strategy().name()`, so `CRYPTO_SHRED` / `FORGETTABLE` surface with no processor change.

## Design notes / consistency with the ADRs

- **`DELETE` / `ANONYMIZE` / `PSEUDONYMIZE` are untouched** and stay the adopter's own `ErasureHandler`: the library cannot know how to delete an arbitrary store (ADR-0004). Only the two append-only-safe strategies have a reusable library handler to auto-wire. `DeclarativeErasureWiringTest#doesNotAutoWireAHandlerForTheLegacyDeleteStrategy` pins this.
- Store beans mirror the existing audit-sink JDBC-or-fallback pattern; overridable by `@ConditionalOnMissingBean` (`#theDefaultStoreBeansAreOverridable`).
- No new runtime dependency, no annotation removed or changed in signature.

## Evidence (spec -> test -> green)

`DeclarativeErasureWiringTest` (6 tests, three fixture types in isolated `declfixture/` packages so each classpath scan finds exactly one). New requirement **REQ-GDPR-024** (EARS + Gherkin + trace-to), README "Declarative: skip the wiring" section + annotations table, CHANGELOG. tracegate catalog regenerated; drift-gate green.

## Local gate

`mvn -B -Dspring-gdpr.it=true clean verify` -> BUILD SUCCESS (all modules, incl. Postgres Testcontainers IT). `tracegate . --check` -> exit 0.

Nothing merged; for your review.