### PR TITLE
fix(#33) + docs(#32): widen payload_value to TEXT, document JitPack auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,59 @@ Distributed via [JitPack](https://jitpack.io/#iambilotta/spring-gdpr). **Maven C
 </repositories>
 ```
 
+> **JitPack authentication (you will hit HTTP 401 without this).** JitPack requires the
+> repository to be authorized in the maintainer's JitPack account before artifacts are
+> served, even for public GitHub repos. This repo is authorized. However, some CI
+> environments and corporate Maven setups need an explicit auth token to resolve from
+> `jitpack.io`. If you see `status code: 401, Unauthorized` / "No access token" in your
+> build log, add the token wiring below. The token is free: log in at
+> [jitpack.io](https://jitpack.io) with your GitHub account, go to **Account > API token**,
+> and copy the personal token shown there.
+>
+> **Maven** (`~/.m2/settings.xml` or CI secret injected as `JITPACK_TOKEN`):
+>
+> ```xml
+> <settings>
+>   <servers>
+>     <server>
+>       <id>jitpack.io</id>          <!-- must match the <repository><id> above -->
+>       <username>your-github-username</username>
+>       <password>${env.JITPACK_TOKEN}</password>
+>     </server>
+>   </servers>
+> </settings>
+> ```
+>
+> In CI (GitHub Actions, Cloud Build, etc.) expose the token as the `JITPACK_TOKEN`
+> environment variable and Maven will pick it up via `${env.JITPACK_TOKEN}`. Do not commit
+> the token value into your `pom.xml` or `settings.xml`.
+>
+> **Gradle** (`~/.gradle/gradle.properties` or equivalent CI secret):
+>
+> ```properties
+> # gradle.properties (not committed to source control)
+> jitpackToken=your-jitpack-token
+> ```
+>
+> ```kotlin
+> // build.gradle.kts
+> repositories {
+>     maven {
+>         url = uri("https://jitpack.io")
+>         credentials {
+>             username = ""                              // JitPack ignores the username
+>             password = providers.gradleProperty("jitpackToken").getOrElse("")
+>         }
+>     }
+> }
+> ```
+>
+> If resolution still fails without a token (anonymous access works for most public builds),
+> try opening `https://jitpack.io/#iambilotta/spring-gdpr` in a browser while signed in to
+> JitPack: this triggers a build for the requested tag and warms the artifact cache.
+> See [JitPack docs](https://jitpack.io/docs/) for further detail on private-repo auth and
+> organization-level tokens.
+
 **2. Add the runtime starter:**
 
 ```xml

--- a/examples/quickstart-postgres/_generated/MANIFEST.md
+++ b/examples/quickstart-postgres/_generated/MANIFEST.md
@@ -1,0 +1,40 @@
+# MANIFEST — spring-gdpr-example-quickstart-postgres auto-generated docs
+
+Read this **first** in a fresh session. Every doc below is regenerated from the code (or tests / migrations / properties / pom) on every commit; the markdown is never the source of truth. Path-only links so any tool that opens the manifest can lazy-load.
+
+## Map
+
+- [`structure.md`](./structure.md) — convention-driven repository tree (git-tracked skeleton) — read first to orient
+
+## Scope & roadmap
+
+- [`requirements.md`](./requirements.md) — tests-as-requirements catalog (FR/NFR/INV/CON/E2E), 100% spec javadoc
+- [`requirements-by-us.md`](./requirements-by-us.md) — tests grouped per User Story with AC coverage gate
+
+## Architecture
+
+- [`modules.md`](./modules.md) — Modulith canvas + cross-module dependency graph + cycle detection
+- [`modules-graph.md`](./modules-graph.md) — Mermaid module-dependency graph (cycles highlighted), renders inline on GitHub/intranet
+- [`domain-model.md`](./domain-model.md) — Mermaid class diagram of the domain: records, sealed hierarchies, enums
+- [`ports.md`](./ports.md) — hexagonal ports → adapters matrix
+- [`templates.md`](./templates.md) — JTE template tree (params + include graph)
+
+## Behavior
+
+- [`http-endpoints.md`](./http-endpoints.md) — every HTTP route with javadoc + contract reference
+- [`state-machine.md`](./state-machine.md) — Mermaid stateDiagram-v2 from a declared transition table (when present)
+
+## State
+
+- [`config.md`](./config.md) — application properties per profile + Java usages
+- [`dependencies.md`](./dependencies.md) — Maven + npm + Python dependency tree
+
+## Quality & debt
+
+- [`coverage.md`](./coverage.md) — JaCoCo per-file coverage with full file list (incl. 0% files)
+- [`todo.md`](./todo.md) — TODO/FIXME/HACK/@Deprecated inventory with git blame
+- [`adr-index.md`](./adr-index.md) — Architecture Decision Record index + auto-detected ADR candidates
+
+---
+
+**Convention**: `_generated/` is gitignored at the repo root (pattern `**/_generated/`) but the tracked `_generated/` of a documented app IS the docs. Pre-commit regenerates everything; never hand-edit a file in this directory.

--- a/examples/quickstart-postgres/_generated/adr-index.md
+++ b/examples/quickstart-postgres/_generated/adr-index.md
@@ -1,0 +1,11 @@
+# ADR index — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated from `apps/gest/decisions/NNNN-*.md`. Title comes from the H1; status from a `Status: ...` line in the body; supported user stories from `US-NNN-slug` citations anywhere in the file. The 'Candidates' section is a heuristic scan of the codebase for load-bearing decisions (feature flags, invariants, contracts, projections) that have NO matching ADR yet — surface, don't autofix.
+
+**Total ADRs**: 0
+
+_No ADR files found under `apps/gest/decisions/`._
+
+## Candidates (auto-detected, 0 signals)
+
+Heuristic. Each signal usually warrants an ADR (a feature flag, an invariant, a contract, a projection design choice are all decisions you'll want to defend in 6 months). Open the file, decide if it's already covered by an existing ADR, otherwise consider writing a new one.

--- a/examples/quickstart-postgres/_generated/coverage.md
+++ b/examples/quickstart-postgres/_generated/coverage.md
@@ -1,0 +1,23 @@
+# Coverage — spring-gdpr-example-quickstart-postgres (as-is)
+
+⚠ **No JaCoCo CSV found** at `apps/gest/target/site/jacoco/jacoco.csv`. Run `make coverage` (alias for `./mvnw test` + regen) and try again. Without the CSV every file below shows 0% — that's the absence of data, not a result.
+
+**Files**: 7 · **Overall line coverage**: 0.0% (0/0)
+
+## By package
+
+| Package | Files | Lines covered | Line % | Branch % |
+|---|---|---|---|---|
+| `com.example.gdprdemo` | 7 | 0/0 | 0.0% | 0.0% |
+
+## Per file (all production sources)
+
+| File | Lines | Line % | Branch % | Methods |
+|---|---|---|---|---|
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/Customer.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/CustomerController.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/CustomerErasureHandler.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/CustomerRepository.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/GdprExportConfig.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/QuickstartApplication.java` | — | — | — | 0/0 |
+| `examples/quickstart-postgres/src/main/java/com/example/gdprdemo/SecurityConfig.java` | — | — | — | 0/0 |

--- a/examples/quickstart-postgres/_generated/dependencies.md
+++ b/examples/quickstart-postgres/_generated/dependencies.md
@@ -1,0 +1,29 @@
+# Dependencies — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated from `pom.xml` (Maven), `frontend/package.json` + `e2e/package.json` (npm), and `scripts/requirements.txt` (Python). Empty version = inherited from Spring Boot parent BOM. Pre-commit refreshes this; if you bump a version anywhere, the diff lands here too.
+
+**Total**: 14 (maven=13, maven (parent)=1)
+
+## maven (13)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.h2database` | `h2` | `(from parent / bom)` | `test` | `examples/quickstart-postgres/pom.xml` |
+| `com.iambilotta.gdpr` | `spring-gdpr-processor` | `${spring-gdpr.version}` | `provided` | `examples/quickstart-postgres/pom.xml` |
+| `com.iambilotta.gdpr` | `spring-gdpr-starter` | `${spring-gdpr.version}` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.flywaydb` | `flyway-core` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.flywaydb` | `flyway-database-postgresql` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.postgresql` | `postgresql` | `(from parent / bom)` | `runtime` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-data-jpa` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-jdbc` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-security` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-test` | `(from parent / bom)` | `test` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-web` | `(from parent / bom)` | `compile` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.boot` | `spring-boot-webmvc-test` | `(from parent / bom)` | `test` | `examples/quickstart-postgres/pom.xml` |
+| `org.springframework.security` | `spring-security-test` | `(from parent / bom)` | `test` | `examples/quickstart-postgres/pom.xml` |
+
+## maven (parent) (1)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `org.springframework.boot` | `spring-boot-starter-parent` | `4.0.5` | `parent` | `examples/quickstart-postgres/pom.xml` |

--- a/examples/quickstart-postgres/_generated/domain-model.md
+++ b/examples/quickstart-postgres/_generated/domain-model.md
@@ -1,0 +1,9 @@
+# Domain model — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated from every type under a `**/domain/**` package, parsed via tree-sitter. Records become classes with their components as fields; a `sealed interface` and its `permits` list become an inheritance hierarchy (`<|--`); enums are tagged `<<enumeration>>` with their constants. This is the shape of the domain the way the code declares it — invalid states made unrepresentable show up as the variant payloads. Run `make code-docs` to regenerate; the source of truth is the code, never this markdown.
+
+**Types**: 0 (0 records · 0 sealed interfaces · 0 enums)
+
+```mermaid
+classDiagram
+```

--- a/examples/quickstart-postgres/_generated/modules-graph.md
+++ b/examples/quickstart-postgres/_generated/modules-graph.md
@@ -1,0 +1,10 @@
+# Module map — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated from the same data as `modules.md`: each top-level package under `com.example.gdprdemo` is a module, the arrows are the cross-module `import` dependencies. A cycle is a Modulith boundary violation (highlighted below). Rendered as Mermaid so it shows inline on GitHub and the intranet. Run `make code-docs`.
+
+✓ No module cycles.
+
+```mermaid
+flowchart TD
+    _root_["(root)<br/>(7 files)"]
+```

--- a/examples/quickstart-postgres/_generated/requirements.md
+++ b/examples/quickstart-postgres/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/examples/quickstart-postgres/_generated/requirements.md
+++ b/examples/quickstart-postgres/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/examples/quickstart-postgres/_generated/state-machine.md
+++ b/examples/quickstart-postgres/_generated/state-machine.md
@@ -1,0 +1,5 @@
+# State machine — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated from every DECLARED transition table (`*Transition` enum under `**/domain/**` whose constants carry their resulting state). The state machine is DATA, so this `stateDiagram-v2` is a pure function of the AST — every arc is derived, never hand-drawn. A transition with no single target state (a generic edit, a removal) is listed below the diagram, not drawn as an arc. Run `make code-docs`; the source of truth is the transition table in the code, never this markdown.
+
+_No declared transition table found. Declare the state machine as data — an enum `<Aggregate>Transition` under a `domain` package whose constants name their resulting state — and tracegate renders the diagram from it (no hand-drawing)._

--- a/examples/quickstart-postgres/_generated/structure.md
+++ b/examples/quickstart-postgres/_generated/structure.md
@@ -1,0 +1,331 @@
+# Structure — `spring-gdpr`
+
+Convention-driven skeleton of the repository: the git-tracked files (respecting `.gitignore`, so no `node_modules` / `target` / build output), rendered as a tree. A single readable snapshot of where everything lives, for a human or an agent orienting in a fresh session. Regenerated on every commit like every `_generated` doc; the source of truth is the filesystem, never this markdown.
+
+_194 tracked paths._
+
+```
+spring-gdpr/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug.md
+│   │   └── feature.md
+│   ├── workflows/
+│   │   ├── ci.yml
+│   │   └── codeql.yml
+│   ├── dependabot.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── pull_request_template.md
+├── .mvn/
+│   └── wrapper/
+│       └── maven-wrapper.properties
+├── docs/
+│   ├── adr/
+│   │   ├── 0000-template.md
+│   │   ├── 0001-annotations-as-source-of-truth.md
+│   │   ├── 0002-async-audit-sink-default.md
+│   │   ├── 0003-build-time-and-runtime-as-two-products.md
+│   │   ├── 0004-erasure-handler-orchestration.md
+│   │   ├── 0005-retention-via-spring-scheduled.md
+│   │   ├── 0006-typed-class-on-spi.md
+│   │   ├── 0007-subjectidfield-is-documentation-only.md
+│   │   ├── 0008-consent-and-portability-deferred.md
+│   │   ├── 0009-append-only-erasure-crypto-shredding.md
+│   │   ├── 0010-forgettable-payload-primary-pattern.md
+│   │   └── README.md
+│   ├── articles/
+│   │   └── 01-gdpr-compliance-by-annotation.md
+│   ├── requirements/
+│   │   └── gdpr.requirements.md
+│   └── DX-review.md
+├── examples/
+│   └── quickstart-postgres/
+│       ├── _generated/
+│       │   ├── config.md
+│       │   ├── http-endpoints.md
+│       │   ├── modules.md
+│       │   ├── ports.md
+│       │   ├── requirements-by-us.md
+│       │   ├── requirements.json
+│       │   ├── requirements.md
+│       │   └── templates.md
+│       ├── src/
+│       │   ├── main/
+│       │   │   ├── java/
+│       │   │   │   └── com/
+│       │   │   │       └── example/
+│       │   │   │           └── gdprdemo/
+│       │   │   │               ├── Customer.java
+│       │   │   │               ├── CustomerController.java
+│       │   │   │               ├── CustomerErasureHandler.java
+│       │   │   │               ├── CustomerRepository.java
+│       │   │   │               ├── GdprExportConfig.java
+│       │   │   │               ├── QuickstartApplication.java
+│       │   │   │               └── SecurityConfig.java
+│       │   │   └── resources/
+│       │   │       ├── db/
+│       │   │       │   └── migration/
+│       │   │       │       ├── V1__gdpr_audit_access.sql
+│       │   │       │       └── V2__customers_table.sql
+│       │   │       ├── application.yml
+│       │   │       └── logback-spring.xml
+│       │   └── test/
+│       │       └── java/
+│       │           └── com/
+│       │               └── example/
+│       │                   └── gdprdemo/
+│       │                       └── QuickstartE2ETest.java
+│       ├── docker-compose.yml
+│       ├── pom.xml
+│       └── README.md
+├── spring-gdpr-annotations/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── annotations/
+│   │                           ├── GdprDataSubjects.java
+│   │                           ├── GdprErasable.java
+│   │                           ├── GdprLegalBasis.java
+│   │                           ├── GdprPersonalData.java
+│   │                           ├── GdprRetention.java
+│   │                           └── package-info.java
+│   └── pom.xml
+├── spring-gdpr-benchmark/
+│   ├── results/
+│   │   └── 2026-05-02-jdk25-corretto.json
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── benchmark/
+│   │                           └── AuditSinkBenchmark.java
+│   ├── pom.xml
+│   └── README.md
+├── spring-gdpr-maven-plugin/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── plugin/
+│   │                           ├── AbstractGdprMojo.java
+│   │                           ├── DpiaMojo.java
+│   │                           ├── RopaMojo.java
+│   │                           └── VerifyMojo.java
+│   └── pom.xml
+├── spring-gdpr-processor/
+│   ├── _generated/
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   └── requirements.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── processor/
+│   │   │   │                   └── GdprAnnotationProcessor.java
+│   │   │   └── resources/
+│   │   │       └── META-INF/
+│   │   │           └── services/
+│   │   │               └── javax.annotation.processing.Processor
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── processor/
+│   │                           └── ProcessingRecordCategoryTest.java
+│   └── pom.xml
+├── spring-gdpr-starter/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── starter/
+│   │   │   │                   ├── access/
+│   │   │   │                   │   ├── AccessExportService.java
+│   │   │   │                   │   ├── ExportedField.java
+│   │   │   │                   │   ├── JdbcSubjectDataProvider.java
+│   │   │   │                   │   ├── SubjectAccessExport.java
+│   │   │   │                   │   └── SubjectDataProvider.java
+│   │   │   │                   ├── audit/
+│   │   │   │                   │   ├── ActorResolver.java
+│   │   │   │                   │   ├── AsyncAuditSinkDecorator.java
+│   │   │   │                   │   ├── AuditAccessRecord.java
+│   │   │   │                   │   ├── AuditSink.java
+│   │   │   │                   │   ├── AuditSinkMetrics.java
+│   │   │   │                   │   ├── JdbcAuditSink.java
+│   │   │   │                   │   ├── PersonalDataAccessAdvisor.java
+│   │   │   │                   │   ├── Slf4jAuditSink.java
+│   │   │   │                   │   └── SubjectIdResolver.java
+│   │   │   │                   ├── autoconfig/
+│   │   │   │                   │   ├── GdprAutoConfiguration.java
+│   │   │   │                   │   └── GdprErasableScannerRegistrar.java
+│   │   │   │                   ├── erasure/
+│   │   │   │                   │   ├── crypto/
+│   │   │   │                   │   │   ├── AesGcmCryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShreddingErasureHandler.java
+│   │   │   │                   │   │   ├── InMemorySubjectKeyStore.java
+│   │   │   │                   │   │   ├── JdbcSubjectKeyStore.java
+│   │   │   │                   │   │   ├── SubjectKeyFactory.java
+│   │   │   │                   │   │   └── SubjectKeyStore.java
+│   │   │   │                   │   ├── forgettable/
+│   │   │   │                   │   │   ├── ForgettablePayloadErasureHandler.java
+│   │   │   │                   │   │   ├── ForgettablePayloadReference.java
+│   │   │   │                   │   │   ├── ForgettablePayloadResolver.java
+│   │   │   │                   │   │   ├── ForgettablePayloadStore.java
+│   │   │   │                   │   │   ├── InMemoryForgettablePayloadStore.java
+│   │   │   │                   │   │   └── JdbcForgettablePayloadStore.java
+│   │   │   │                   │   ├── CompositeSubjectErasureHandler.java
+│   │   │   │                   │   ├── ErasureHandler.java
+│   │   │   │                   │   ├── ErasureListener.java
+│   │   │   │                   │   ├── ErasureListenerException.java
+│   │   │   │                   │   ├── ErasureReport.java
+│   │   │   │                   │   ├── ErasureService.java
+│   │   │   │                   │   ├── JdbcErasureHandler.java
+│   │   │   │                   │   └── SubjectErasedEvent.java
+│   │   │   │                   ├── jdbc/
+│   │   │   │                   │   └── SqlIdentifiers.java
+│   │   │   │                   ├── logging/
+│   │   │   │                   │   ├── PiiMasker.java
+│   │   │   │                   │   └── PiiMaskingConverter.java
+│   │   │   │                   ├── retention/
+│   │   │   │                   │   ├── JdbcRetentionTarget.java
+│   │   │   │                   │   ├── RetentionScheduler.java
+│   │   │   │                   │   └── RetentionTarget.java
+│   │   │   │                   ├── web/
+│   │   │   │                   │   ├── GdprController.java
+│   │   │   │                   │   ├── GdprExceptionHandler.java
+│   │   │   │                   │   └── GdprSecurityWarning.java
+│   │   │   │                   └── GdprProperties.java
+│   │   │   └── resources/
+│   │   │       ├── db/
+│   │   │       │   ├── changelog/
+│   │   │       │   │   └── spring-gdpr-changelog.xml
+│   │   │       │   └── migration/
+│   │   │       │       ├── V1__gdpr_audit_access.sql
+│   │   │       │       ├── V2__gdpr_subject_key.sql
+│   │   │       │       └── V3__gdpr_forgettable_payload.sql
+│   │   │       └── META-INF/
+│   │   │           ├── spring/
+│   │   │           │   └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
+│   │   │           └── additional-spring-configuration-metadata.json
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── starter/
+│   │                           ├── access/
+│   │                           │   ├── AccessExportServiceTest.java
+│   │                           │   └── JdbcSubjectDataProviderTest.java
+│   │                           ├── audit/
+│   │                           │   ├── AsyncAuditSinkDecoratorTest.java
+│   │                           │   ├── AuditSinkMetricsTest.java
+│   │                           │   ├── JdbcAuditSinkPostgresIT.java
+│   │                           │   ├── JdbcAuditSinkTest.java
+│   │                           │   ├── LegalBasisMappingTest.java
+│   │                           │   └── PersonalDataAccessAdvisorTest.java
+│   │                           ├── autoconfig/
+│   │                           │   ├── declfixture/
+│   │                           │   │   ├── crypto/
+│   │                           │   │   │   └── CryptoShreddedEntity.java
+│   │                           │   │   ├── forgettable/
+│   │                           │   │   │   └── ForgettableEntity.java
+│   │                           │   │   └── legacy/
+│   │                           │   │       └── DeleteEntity.java
+│   │                           │   ├── DeclarativeErasureWiringTest.java
+│   │                           │   └── GdprAutoConfigurationTest.java
+│   │                           ├── erasure/
+│   │                           │   ├── crypto/
+│   │                           │   │   ├── AesGcmCryptoShredderTest.java
+│   │                           │   │   └── JdbcSubjectKeyStoreTest.java
+│   │                           │   ├── forgettable/
+│   │                           │   │   ├── CompositeSubjectErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadReferenceTest.java
+│   │                           │   │   ├── ForgettablePayloadResolverTest.java
+│   │                           │   │   ├── GdprPersonalDataStorageTest.java
+│   │                           │   │   ├── InMemoryForgettablePayloadStoreTest.java
+│   │                           │   │   └── JdbcForgettablePayloadStoreTest.java
+│   │                           │   ├── CryptoShreddingErasureTest.java
+│   │                           │   ├── ErasureListenerTest.java
+│   │                           │   ├── ErasureServiceTest.java
+│   │                           │   └── JdbcErasureHandlerTest.java
+│   │                           ├── logging/
+│   │                           │   ├── PiiMaskerTest.java
+│   │                           │   └── PiiMaskingConverterTest.java
+│   │                           ├── retention/
+│   │                           │   ├── JdbcRetentionTargetTest.java
+│   │                           │   └── RetentionSchedulerTest.java
+│   │                           └── web/
+│   │                               ├── GdprControllerTest.java
+│   │                               └── GdprSecurityWarningTest.java
+│   └── pom.xml
+├── spring-gdpr-starter-test/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   └── java/
+│   │   │       └── com/
+│   │   │           └── iambilotta/
+│   │   │               └── gdpr/
+│   │   │                   └── demo/
+│   │   │                       ├── Customer.java
+│   │   │                       ├── CustomerErasureHandler.java
+│   │   │                       ├── CustomerRepository.java
+│   │   │                       └── DemoApplication.java
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── demo/
+│   │                           └── GdprIntegrationTest.java
+│   └── pom.xml
+├── .editorconfig
+├── .gitignore
+├── CHANGELOG.md
+├── CITATION.cff
+├── CLAUDE.md
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING.md
+├── jitpack.yml
+├── LICENSE
+├── Makefile
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+├── README.md
+├── SECURITY.md
+├── SUPPORT.md
+└── tracegate.toml
+```

--- a/examples/quickstart-postgres/_generated/todo.md
+++ b/examples/quickstart-postgres/_generated/todo.md
@@ -1,0 +1,7 @@
+# Tech debt inventory — spring-gdpr-example-quickstart-postgres (as-is)
+
+Auto-generated. Every `TODO` / `FIXME` / `XXX` / `HACK` marker plus every `@Deprecated` in the authored sources is listed below, with `git blame` author and age in days. The purpose is **visibility**: nothing here is automatically blocking, but a marker that ages past 90 days is usually either done-by-other-means (delete the marker) or stale debt that should become an ADR or an issue.
+
+**Total markers**: 0
+
+✓ Zero markers in the authored sources right now.

--- a/spring-gdpr-processor/_generated/MANIFEST.md
+++ b/spring-gdpr-processor/_generated/MANIFEST.md
@@ -1,0 +1,26 @@
+# MANIFEST — spring-gdpr-processor auto-generated docs
+
+Read this **first** in a fresh session. Every doc below is regenerated from the code (or tests / migrations / properties / pom) on every commit; the markdown is never the source of truth. Path-only links so any tool that opens the manifest can lazy-load.
+
+## Map
+
+- [`structure.md`](./structure.md) — convention-driven repository tree (git-tracked skeleton) — read first to orient
+
+## Scope & roadmap
+
+- [`requirements.md`](./requirements.md) — tests-as-requirements catalog (FR/NFR/INV/CON/E2E), 100% spec javadoc
+- [`requirements-by-us.md`](./requirements-by-us.md) — tests grouped per User Story with AC coverage gate
+
+## State
+
+- [`dependencies.md`](./dependencies.md) — Maven + npm + Python dependency tree
+
+## Quality & debt
+
+- [`coverage.md`](./coverage.md) — JaCoCo per-file coverage with full file list (incl. 0% files)
+- [`todo.md`](./todo.md) — TODO/FIXME/HACK/@Deprecated inventory with git blame
+- [`adr-index.md`](./adr-index.md) — Architecture Decision Record index + auto-detected ADR candidates
+
+---
+
+**Convention**: `_generated/` is gitignored at the repo root (pattern `**/_generated/`) but the tracked `_generated/` of a documented app IS the docs. Pre-commit regenerates everything; never hand-edit a file in this directory.

--- a/spring-gdpr-processor/_generated/adr-index.md
+++ b/spring-gdpr-processor/_generated/adr-index.md
@@ -1,0 +1,11 @@
+# ADR index — spring-gdpr-processor (as-is)
+
+Auto-generated from `apps/gest/decisions/NNNN-*.md`. Title comes from the H1; status from a `Status: ...` line in the body; supported user stories from `US-NNN-slug` citations anywhere in the file. The 'Candidates' section is a heuristic scan of the codebase for load-bearing decisions (feature flags, invariants, contracts, projections) that have NO matching ADR yet — surface, don't autofix.
+
+**Total ADRs**: 0
+
+_No ADR files found under `apps/gest/decisions/`._
+
+## Candidates (auto-detected, 0 signals)
+
+Heuristic. Each signal usually warrants an ADR (a feature flag, an invariant, a contract, a projection design choice are all decisions you'll want to defend in 6 months). Open the file, decide if it's already covered by an existing ADR, otherwise consider writing a new one.

--- a/spring-gdpr-processor/_generated/coverage.md
+++ b/spring-gdpr-processor/_generated/coverage.md
@@ -1,0 +1,17 @@
+# Coverage — spring-gdpr-processor (as-is)
+
+⚠ **No JaCoCo CSV found** at `apps/gest/target/site/jacoco/jacoco.csv`. Run `make coverage` (alias for `./mvnw test` + regen) and try again. Without the CSV every file below shows 0% — that's the absence of data, not a result.
+
+**Files**: 1 · **Overall line coverage**: 0.0% (0/0)
+
+## By package
+
+| Package | Files | Lines covered | Line % | Branch % |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr.processor` | 1 | 0/0 | 0.0% | 0.0% |
+
+## Per file (all production sources)
+
+| File | Lines | Line % | Branch % | Methods |
+|---|---|---|---|---|
+| `com/iambilotta/gdpr/processor/GdprAnnotationProcessor.java` | — | — | — | 0/0 |

--- a/spring-gdpr-processor/_generated/dependencies.md
+++ b/spring-gdpr-processor/_generated/dependencies.md
@@ -1,0 +1,19 @@
+# Dependencies — spring-gdpr-processor (as-is)
+
+Auto-generated from `pom.xml` (Maven), `frontend/package.json` + `e2e/package.json` (npm), and `scripts/requirements.txt` (Python). Empty version = inherited from Spring Boot parent BOM. Pre-commit refreshes this; if you bump a version anywhere, the diff lands here too.
+
+**Total**: 4 (maven=3, maven (parent)=1)
+
+## maven (3)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr` | `spring-gdpr-annotations` | `(from parent / bom)` | `compile` | `spring-gdpr-processor/pom.xml` |
+| `org.assertj` | `assertj-core` | `(from parent / bom)` | `test` | `spring-gdpr-processor/pom.xml` |
+| `org.junit.jupiter` | `junit-jupiter` | `(from parent / bom)` | `test` | `spring-gdpr-processor/pom.xml` |
+
+## maven (parent) (1)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr` | `spring-gdpr-parent` | `2.0.0` | `parent` | `spring-gdpr-processor/pom.xml` |

--- a/spring-gdpr-processor/_generated/requirements.md
+++ b/spring-gdpr-processor/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/spring-gdpr-processor/_generated/requirements.md
+++ b/spring-gdpr-processor/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/spring-gdpr-processor/_generated/structure.md
+++ b/spring-gdpr-processor/_generated/structure.md
@@ -1,0 +1,331 @@
+# Structure — `spring-gdpr`
+
+Convention-driven skeleton of the repository: the git-tracked files (respecting `.gitignore`, so no `node_modules` / `target` / build output), rendered as a tree. A single readable snapshot of where everything lives, for a human or an agent orienting in a fresh session. Regenerated on every commit like every `_generated` doc; the source of truth is the filesystem, never this markdown.
+
+_194 tracked paths._
+
+```
+spring-gdpr/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug.md
+│   │   └── feature.md
+│   ├── workflows/
+│   │   ├── ci.yml
+│   │   └── codeql.yml
+│   ├── dependabot.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── pull_request_template.md
+├── .mvn/
+│   └── wrapper/
+│       └── maven-wrapper.properties
+├── docs/
+│   ├── adr/
+│   │   ├── 0000-template.md
+│   │   ├── 0001-annotations-as-source-of-truth.md
+│   │   ├── 0002-async-audit-sink-default.md
+│   │   ├── 0003-build-time-and-runtime-as-two-products.md
+│   │   ├── 0004-erasure-handler-orchestration.md
+│   │   ├── 0005-retention-via-spring-scheduled.md
+│   │   ├── 0006-typed-class-on-spi.md
+│   │   ├── 0007-subjectidfield-is-documentation-only.md
+│   │   ├── 0008-consent-and-portability-deferred.md
+│   │   ├── 0009-append-only-erasure-crypto-shredding.md
+│   │   ├── 0010-forgettable-payload-primary-pattern.md
+│   │   └── README.md
+│   ├── articles/
+│   │   └── 01-gdpr-compliance-by-annotation.md
+│   ├── requirements/
+│   │   └── gdpr.requirements.md
+│   └── DX-review.md
+├── examples/
+│   └── quickstart-postgres/
+│       ├── _generated/
+│       │   ├── config.md
+│       │   ├── http-endpoints.md
+│       │   ├── modules.md
+│       │   ├── ports.md
+│       │   ├── requirements-by-us.md
+│       │   ├── requirements.json
+│       │   ├── requirements.md
+│       │   └── templates.md
+│       ├── src/
+│       │   ├── main/
+│       │   │   ├── java/
+│       │   │   │   └── com/
+│       │   │   │       └── example/
+│       │   │   │           └── gdprdemo/
+│       │   │   │               ├── Customer.java
+│       │   │   │               ├── CustomerController.java
+│       │   │   │               ├── CustomerErasureHandler.java
+│       │   │   │               ├── CustomerRepository.java
+│       │   │   │               ├── GdprExportConfig.java
+│       │   │   │               ├── QuickstartApplication.java
+│       │   │   │               └── SecurityConfig.java
+│       │   │   └── resources/
+│       │   │       ├── db/
+│       │   │       │   └── migration/
+│       │   │       │       ├── V1__gdpr_audit_access.sql
+│       │   │       │       └── V2__customers_table.sql
+│       │   │       ├── application.yml
+│       │   │       └── logback-spring.xml
+│       │   └── test/
+│       │       └── java/
+│       │           └── com/
+│       │               └── example/
+│       │                   └── gdprdemo/
+│       │                       └── QuickstartE2ETest.java
+│       ├── docker-compose.yml
+│       ├── pom.xml
+│       └── README.md
+├── spring-gdpr-annotations/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── annotations/
+│   │                           ├── GdprDataSubjects.java
+│   │                           ├── GdprErasable.java
+│   │                           ├── GdprLegalBasis.java
+│   │                           ├── GdprPersonalData.java
+│   │                           ├── GdprRetention.java
+│   │                           └── package-info.java
+│   └── pom.xml
+├── spring-gdpr-benchmark/
+│   ├── results/
+│   │   └── 2026-05-02-jdk25-corretto.json
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── benchmark/
+│   │                           └── AuditSinkBenchmark.java
+│   ├── pom.xml
+│   └── README.md
+├── spring-gdpr-maven-plugin/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── plugin/
+│   │                           ├── AbstractGdprMojo.java
+│   │                           ├── DpiaMojo.java
+│   │                           ├── RopaMojo.java
+│   │                           └── VerifyMojo.java
+│   └── pom.xml
+├── spring-gdpr-processor/
+│   ├── _generated/
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   └── requirements.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── processor/
+│   │   │   │                   └── GdprAnnotationProcessor.java
+│   │   │   └── resources/
+│   │   │       └── META-INF/
+│   │   │           └── services/
+│   │   │               └── javax.annotation.processing.Processor
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── processor/
+│   │                           └── ProcessingRecordCategoryTest.java
+│   └── pom.xml
+├── spring-gdpr-starter/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── starter/
+│   │   │   │                   ├── access/
+│   │   │   │                   │   ├── AccessExportService.java
+│   │   │   │                   │   ├── ExportedField.java
+│   │   │   │                   │   ├── JdbcSubjectDataProvider.java
+│   │   │   │                   │   ├── SubjectAccessExport.java
+│   │   │   │                   │   └── SubjectDataProvider.java
+│   │   │   │                   ├── audit/
+│   │   │   │                   │   ├── ActorResolver.java
+│   │   │   │                   │   ├── AsyncAuditSinkDecorator.java
+│   │   │   │                   │   ├── AuditAccessRecord.java
+│   │   │   │                   │   ├── AuditSink.java
+│   │   │   │                   │   ├── AuditSinkMetrics.java
+│   │   │   │                   │   ├── JdbcAuditSink.java
+│   │   │   │                   │   ├── PersonalDataAccessAdvisor.java
+│   │   │   │                   │   ├── Slf4jAuditSink.java
+│   │   │   │                   │   └── SubjectIdResolver.java
+│   │   │   │                   ├── autoconfig/
+│   │   │   │                   │   ├── GdprAutoConfiguration.java
+│   │   │   │                   │   └── GdprErasableScannerRegistrar.java
+│   │   │   │                   ├── erasure/
+│   │   │   │                   │   ├── crypto/
+│   │   │   │                   │   │   ├── AesGcmCryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShreddingErasureHandler.java
+│   │   │   │                   │   │   ├── InMemorySubjectKeyStore.java
+│   │   │   │                   │   │   ├── JdbcSubjectKeyStore.java
+│   │   │   │                   │   │   ├── SubjectKeyFactory.java
+│   │   │   │                   │   │   └── SubjectKeyStore.java
+│   │   │   │                   │   ├── forgettable/
+│   │   │   │                   │   │   ├── ForgettablePayloadErasureHandler.java
+│   │   │   │                   │   │   ├── ForgettablePayloadReference.java
+│   │   │   │                   │   │   ├── ForgettablePayloadResolver.java
+│   │   │   │                   │   │   ├── ForgettablePayloadStore.java
+│   │   │   │                   │   │   ├── InMemoryForgettablePayloadStore.java
+│   │   │   │                   │   │   └── JdbcForgettablePayloadStore.java
+│   │   │   │                   │   ├── CompositeSubjectErasureHandler.java
+│   │   │   │                   │   ├── ErasureHandler.java
+│   │   │   │                   │   ├── ErasureListener.java
+│   │   │   │                   │   ├── ErasureListenerException.java
+│   │   │   │                   │   ├── ErasureReport.java
+│   │   │   │                   │   ├── ErasureService.java
+│   │   │   │                   │   ├── JdbcErasureHandler.java
+│   │   │   │                   │   └── SubjectErasedEvent.java
+│   │   │   │                   ├── jdbc/
+│   │   │   │                   │   └── SqlIdentifiers.java
+│   │   │   │                   ├── logging/
+│   │   │   │                   │   ├── PiiMasker.java
+│   │   │   │                   │   └── PiiMaskingConverter.java
+│   │   │   │                   ├── retention/
+│   │   │   │                   │   ├── JdbcRetentionTarget.java
+│   │   │   │                   │   ├── RetentionScheduler.java
+│   │   │   │                   │   └── RetentionTarget.java
+│   │   │   │                   ├── web/
+│   │   │   │                   │   ├── GdprController.java
+│   │   │   │                   │   ├── GdprExceptionHandler.java
+│   │   │   │                   │   └── GdprSecurityWarning.java
+│   │   │   │                   └── GdprProperties.java
+│   │   │   └── resources/
+│   │   │       ├── db/
+│   │   │       │   ├── changelog/
+│   │   │       │   │   └── spring-gdpr-changelog.xml
+│   │   │       │   └── migration/
+│   │   │       │       ├── V1__gdpr_audit_access.sql
+│   │   │       │       ├── V2__gdpr_subject_key.sql
+│   │   │       │       └── V3__gdpr_forgettable_payload.sql
+│   │   │       └── META-INF/
+│   │   │           ├── spring/
+│   │   │           │   └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
+│   │   │           └── additional-spring-configuration-metadata.json
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── starter/
+│   │                           ├── access/
+│   │                           │   ├── AccessExportServiceTest.java
+│   │                           │   └── JdbcSubjectDataProviderTest.java
+│   │                           ├── audit/
+│   │                           │   ├── AsyncAuditSinkDecoratorTest.java
+│   │                           │   ├── AuditSinkMetricsTest.java
+│   │                           │   ├── JdbcAuditSinkPostgresIT.java
+│   │                           │   ├── JdbcAuditSinkTest.java
+│   │                           │   ├── LegalBasisMappingTest.java
+│   │                           │   └── PersonalDataAccessAdvisorTest.java
+│   │                           ├── autoconfig/
+│   │                           │   ├── declfixture/
+│   │                           │   │   ├── crypto/
+│   │                           │   │   │   └── CryptoShreddedEntity.java
+│   │                           │   │   ├── forgettable/
+│   │                           │   │   │   └── ForgettableEntity.java
+│   │                           │   │   └── legacy/
+│   │                           │   │       └── DeleteEntity.java
+│   │                           │   ├── DeclarativeErasureWiringTest.java
+│   │                           │   └── GdprAutoConfigurationTest.java
+│   │                           ├── erasure/
+│   │                           │   ├── crypto/
+│   │                           │   │   ├── AesGcmCryptoShredderTest.java
+│   │                           │   │   └── JdbcSubjectKeyStoreTest.java
+│   │                           │   ├── forgettable/
+│   │                           │   │   ├── CompositeSubjectErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadReferenceTest.java
+│   │                           │   │   ├── ForgettablePayloadResolverTest.java
+│   │                           │   │   ├── GdprPersonalDataStorageTest.java
+│   │                           │   │   ├── InMemoryForgettablePayloadStoreTest.java
+│   │                           │   │   └── JdbcForgettablePayloadStoreTest.java
+│   │                           │   ├── CryptoShreddingErasureTest.java
+│   │                           │   ├── ErasureListenerTest.java
+│   │                           │   ├── ErasureServiceTest.java
+│   │                           │   └── JdbcErasureHandlerTest.java
+│   │                           ├── logging/
+│   │                           │   ├── PiiMaskerTest.java
+│   │                           │   └── PiiMaskingConverterTest.java
+│   │                           ├── retention/
+│   │                           │   ├── JdbcRetentionTargetTest.java
+│   │                           │   └── RetentionSchedulerTest.java
+│   │                           └── web/
+│   │                               ├── GdprControllerTest.java
+│   │                               └── GdprSecurityWarningTest.java
+│   └── pom.xml
+├── spring-gdpr-starter-test/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   └── java/
+│   │   │       └── com/
+│   │   │           └── iambilotta/
+│   │   │               └── gdpr/
+│   │   │                   └── demo/
+│   │   │                       ├── Customer.java
+│   │   │                       ├── CustomerErasureHandler.java
+│   │   │                       ├── CustomerRepository.java
+│   │   │                       └── DemoApplication.java
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── demo/
+│   │                           └── GdprIntegrationTest.java
+│   └── pom.xml
+├── .editorconfig
+├── .gitignore
+├── CHANGELOG.md
+├── CITATION.cff
+├── CLAUDE.md
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING.md
+├── jitpack.yml
+├── LICENSE
+├── Makefile
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+├── README.md
+├── SECURITY.md
+├── SUPPORT.md
+└── tracegate.toml
+```

--- a/spring-gdpr-processor/_generated/todo.md
+++ b/spring-gdpr-processor/_generated/todo.md
@@ -1,0 +1,7 @@
+# Tech debt inventory — spring-gdpr-processor (as-is)
+
+Auto-generated. Every `TODO` / `FIXME` / `XXX` / `HACK` marker plus every `@Deprecated` in the authored sources is listed below, with `git blame` author and age in days. The purpose is **visibility**: nothing here is automatically blocking, but a marker that ages past 90 days is usually either done-by-other-means (delete the marker) or stale debt that should become an ADR or an issue.
+
+**Total markers**: 0
+
+✓ Zero markers in the authored sources right now.

--- a/spring-gdpr-starter-test/_generated/MANIFEST.md
+++ b/spring-gdpr-starter-test/_generated/MANIFEST.md
@@ -1,0 +1,40 @@
+# MANIFEST — spring-gdpr-starter-test auto-generated docs
+
+Read this **first** in a fresh session. Every doc below is regenerated from the code (or tests / migrations / properties / pom) on every commit; the markdown is never the source of truth. Path-only links so any tool that opens the manifest can lazy-load.
+
+## Map
+
+- [`structure.md`](./structure.md) — convention-driven repository tree (git-tracked skeleton) — read first to orient
+
+## Scope & roadmap
+
+- [`requirements.md`](./requirements.md) — tests-as-requirements catalog (FR/NFR/INV/CON/E2E), 100% spec javadoc
+- [`requirements-by-us.md`](./requirements-by-us.md) — tests grouped per User Story with AC coverage gate
+
+## Architecture
+
+- [`modules.md`](./modules.md) — Modulith canvas + cross-module dependency graph + cycle detection
+- [`modules-graph.md`](./modules-graph.md) — Mermaid module-dependency graph (cycles highlighted), renders inline on GitHub/intranet
+- [`domain-model.md`](./domain-model.md) — Mermaid class diagram of the domain: records, sealed hierarchies, enums
+- [`ports.md`](./ports.md) — hexagonal ports → adapters matrix
+- [`templates.md`](./templates.md) — JTE template tree (params + include graph)
+
+## Behavior
+
+- [`http-endpoints.md`](./http-endpoints.md) — every HTTP route with javadoc + contract reference
+- [`state-machine.md`](./state-machine.md) — Mermaid stateDiagram-v2 from a declared transition table (when present)
+
+## State
+
+- [`config.md`](./config.md) — application properties per profile + Java usages
+- [`dependencies.md`](./dependencies.md) — Maven + npm + Python dependency tree
+
+## Quality & debt
+
+- [`coverage.md`](./coverage.md) — JaCoCo per-file coverage with full file list (incl. 0% files)
+- [`todo.md`](./todo.md) — TODO/FIXME/HACK/@Deprecated inventory with git blame
+- [`adr-index.md`](./adr-index.md) — Architecture Decision Record index + auto-detected ADR candidates
+
+---
+
+**Convention**: `_generated/` is gitignored at the repo root (pattern `**/_generated/`) but the tracked `_generated/` of a documented app IS the docs. Pre-commit regenerates everything; never hand-edit a file in this directory.

--- a/spring-gdpr-starter-test/_generated/adr-index.md
+++ b/spring-gdpr-starter-test/_generated/adr-index.md
@@ -1,0 +1,11 @@
+# ADR index — spring-gdpr-starter-test (as-is)
+
+Auto-generated from `apps/gest/decisions/NNNN-*.md`. Title comes from the H1; status from a `Status: ...` line in the body; supported user stories from `US-NNN-slug` citations anywhere in the file. The 'Candidates' section is a heuristic scan of the codebase for load-bearing decisions (feature flags, invariants, contracts, projections) that have NO matching ADR yet — surface, don't autofix.
+
+**Total ADRs**: 0
+
+_No ADR files found under `apps/gest/decisions/`._
+
+## Candidates (auto-detected, 0 signals)
+
+Heuristic. Each signal usually warrants an ADR (a feature flag, an invariant, a contract, a projection design choice are all decisions you'll want to defend in 6 months). Open the file, decide if it's already covered by an existing ADR, otherwise consider writing a new one.

--- a/spring-gdpr-starter-test/_generated/coverage.md
+++ b/spring-gdpr-starter-test/_generated/coverage.md
@@ -1,0 +1,20 @@
+# Coverage — spring-gdpr-starter-test (as-is)
+
+⚠ **No JaCoCo CSV found** at `apps/gest/target/site/jacoco/jacoco.csv`. Run `make coverage` (alias for `./mvnw test` + regen) and try again. Without the CSV every file below shows 0% — that's the absence of data, not a result.
+
+**Files**: 4 · **Overall line coverage**: 0.0% (0/0)
+
+## By package
+
+| Package | Files | Lines covered | Line % | Branch % |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr.demo` | 4 | 0/0 | 0.0% | 0.0% |
+
+## Per file (all production sources)
+
+| File | Lines | Line % | Branch % | Methods |
+|---|---|---|---|---|
+| `com/iambilotta/gdpr/demo/Customer.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/demo/CustomerErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/demo/CustomerRepository.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/demo/DemoApplication.java` | — | — | — | 0/0 |

--- a/spring-gdpr-starter-test/_generated/dependencies.md
+++ b/spring-gdpr-starter-test/_generated/dependencies.md
@@ -1,0 +1,23 @@
+# Dependencies — spring-gdpr-starter-test (as-is)
+
+Auto-generated from `pom.xml` (Maven), `frontend/package.json` + `e2e/package.json` (npm), and `scripts/requirements.txt` (Python). Empty version = inherited from Spring Boot parent BOM. Pre-commit refreshes this; if you bump a version anywhere, the diff lands here too.
+
+**Total**: 8 (maven=7, maven (parent)=1)
+
+## maven (7)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.h2database` | `h2` | `(from parent / bom)` | `test` | `spring-gdpr-starter-test/pom.xml` |
+| `com.iambilotta.gdpr` | `spring-gdpr-processor` | `(from parent / bom)` | `provided` | `spring-gdpr-starter-test/pom.xml` |
+| `com.iambilotta.gdpr` | `spring-gdpr-starter` | `(from parent / bom)` | `compile` | `spring-gdpr-starter-test/pom.xml` |
+| `org.assertj` | `assertj-core` | `(from parent / bom)` | `test` | `spring-gdpr-starter-test/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-jdbc` | `(from parent / bom)` | `test` | `spring-gdpr-starter-test/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-test` | `(from parent / bom)` | `test` | `spring-gdpr-starter-test/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-web` | `(from parent / bom)` | `compile` | `spring-gdpr-starter-test/pom.xml` |
+
+## maven (parent) (1)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr` | `spring-gdpr-parent` | `2.0.0` | `parent` | `spring-gdpr-starter-test/pom.xml` |

--- a/spring-gdpr-starter-test/_generated/domain-model.md
+++ b/spring-gdpr-starter-test/_generated/domain-model.md
@@ -1,0 +1,9 @@
+# Domain model — spring-gdpr-starter-test (as-is)
+
+Auto-generated from every type under a `**/domain/**` package, parsed via tree-sitter. Records become classes with their components as fields; a `sealed interface` and its `permits` list become an inheritance hierarchy (`<|--`); enums are tagged `<<enumeration>>` with their constants. This is the shape of the domain the way the code declares it — invalid states made unrepresentable show up as the variant payloads. Run `make code-docs` to regenerate; the source of truth is the code, never this markdown.
+
+**Types**: 0 (0 records · 0 sealed interfaces · 0 enums)
+
+```mermaid
+classDiagram
+```

--- a/spring-gdpr-starter-test/_generated/modules-graph.md
+++ b/spring-gdpr-starter-test/_generated/modules-graph.md
@@ -1,0 +1,10 @@
+# Module map — spring-gdpr-starter-test (as-is)
+
+Auto-generated from the same data as `modules.md`: each top-level package under `com.iambilotta.gdpr.demo` is a module, the arrows are the cross-module `import` dependencies. A cycle is a Modulith boundary violation (highlighted below). Rendered as Mermaid so it shows inline on GitHub and the intranet. Run `make code-docs`.
+
+✓ No module cycles.
+
+```mermaid
+flowchart TD
+    _root_["(root)<br/>(4 files)"]
+```

--- a/spring-gdpr-starter-test/_generated/requirements.md
+++ b/spring-gdpr-starter-test/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/spring-gdpr-starter-test/_generated/requirements.md
+++ b/spring-gdpr-starter-test/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/spring-gdpr-starter-test/_generated/state-machine.md
+++ b/spring-gdpr-starter-test/_generated/state-machine.md
@@ -1,0 +1,5 @@
+# State machine — spring-gdpr-starter-test (as-is)
+
+Auto-generated from every DECLARED transition table (`*Transition` enum under `**/domain/**` whose constants carry their resulting state). The state machine is DATA, so this `stateDiagram-v2` is a pure function of the AST — every arc is derived, never hand-drawn. A transition with no single target state (a generic edit, a removal) is listed below the diagram, not drawn as an arc. Run `make code-docs`; the source of truth is the transition table in the code, never this markdown.
+
+_No declared transition table found. Declare the state machine as data — an enum `<Aggregate>Transition` under a `domain` package whose constants name their resulting state — and tracegate renders the diagram from it (no hand-drawing)._

--- a/spring-gdpr-starter-test/_generated/structure.md
+++ b/spring-gdpr-starter-test/_generated/structure.md
@@ -1,0 +1,331 @@
+# Structure — `spring-gdpr`
+
+Convention-driven skeleton of the repository: the git-tracked files (respecting `.gitignore`, so no `node_modules` / `target` / build output), rendered as a tree. A single readable snapshot of where everything lives, for a human or an agent orienting in a fresh session. Regenerated on every commit like every `_generated` doc; the source of truth is the filesystem, never this markdown.
+
+_194 tracked paths._
+
+```
+spring-gdpr/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug.md
+│   │   └── feature.md
+│   ├── workflows/
+│   │   ├── ci.yml
+│   │   └── codeql.yml
+│   ├── dependabot.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── pull_request_template.md
+├── .mvn/
+│   └── wrapper/
+│       └── maven-wrapper.properties
+├── docs/
+│   ├── adr/
+│   │   ├── 0000-template.md
+│   │   ├── 0001-annotations-as-source-of-truth.md
+│   │   ├── 0002-async-audit-sink-default.md
+│   │   ├── 0003-build-time-and-runtime-as-two-products.md
+│   │   ├── 0004-erasure-handler-orchestration.md
+│   │   ├── 0005-retention-via-spring-scheduled.md
+│   │   ├── 0006-typed-class-on-spi.md
+│   │   ├── 0007-subjectidfield-is-documentation-only.md
+│   │   ├── 0008-consent-and-portability-deferred.md
+│   │   ├── 0009-append-only-erasure-crypto-shredding.md
+│   │   ├── 0010-forgettable-payload-primary-pattern.md
+│   │   └── README.md
+│   ├── articles/
+│   │   └── 01-gdpr-compliance-by-annotation.md
+│   ├── requirements/
+│   │   └── gdpr.requirements.md
+│   └── DX-review.md
+├── examples/
+│   └── quickstart-postgres/
+│       ├── _generated/
+│       │   ├── config.md
+│       │   ├── http-endpoints.md
+│       │   ├── modules.md
+│       │   ├── ports.md
+│       │   ├── requirements-by-us.md
+│       │   ├── requirements.json
+│       │   ├── requirements.md
+│       │   └── templates.md
+│       ├── src/
+│       │   ├── main/
+│       │   │   ├── java/
+│       │   │   │   └── com/
+│       │   │   │       └── example/
+│       │   │   │           └── gdprdemo/
+│       │   │   │               ├── Customer.java
+│       │   │   │               ├── CustomerController.java
+│       │   │   │               ├── CustomerErasureHandler.java
+│       │   │   │               ├── CustomerRepository.java
+│       │   │   │               ├── GdprExportConfig.java
+│       │   │   │               ├── QuickstartApplication.java
+│       │   │   │               └── SecurityConfig.java
+│       │   │   └── resources/
+│       │   │       ├── db/
+│       │   │       │   └── migration/
+│       │   │       │       ├── V1__gdpr_audit_access.sql
+│       │   │       │       └── V2__customers_table.sql
+│       │   │       ├── application.yml
+│       │   │       └── logback-spring.xml
+│       │   └── test/
+│       │       └── java/
+│       │           └── com/
+│       │               └── example/
+│       │                   └── gdprdemo/
+│       │                       └── QuickstartE2ETest.java
+│       ├── docker-compose.yml
+│       ├── pom.xml
+│       └── README.md
+├── spring-gdpr-annotations/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── annotations/
+│   │                           ├── GdprDataSubjects.java
+│   │                           ├── GdprErasable.java
+│   │                           ├── GdprLegalBasis.java
+│   │                           ├── GdprPersonalData.java
+│   │                           ├── GdprRetention.java
+│   │                           └── package-info.java
+│   └── pom.xml
+├── spring-gdpr-benchmark/
+│   ├── results/
+│   │   └── 2026-05-02-jdk25-corretto.json
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── benchmark/
+│   │                           └── AuditSinkBenchmark.java
+│   ├── pom.xml
+│   └── README.md
+├── spring-gdpr-maven-plugin/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── plugin/
+│   │                           ├── AbstractGdprMojo.java
+│   │                           ├── DpiaMojo.java
+│   │                           ├── RopaMojo.java
+│   │                           └── VerifyMojo.java
+│   └── pom.xml
+├── spring-gdpr-processor/
+│   ├── _generated/
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   └── requirements.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── processor/
+│   │   │   │                   └── GdprAnnotationProcessor.java
+│   │   │   └── resources/
+│   │   │       └── META-INF/
+│   │   │           └── services/
+│   │   │               └── javax.annotation.processing.Processor
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── processor/
+│   │                           └── ProcessingRecordCategoryTest.java
+│   └── pom.xml
+├── spring-gdpr-starter/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── starter/
+│   │   │   │                   ├── access/
+│   │   │   │                   │   ├── AccessExportService.java
+│   │   │   │                   │   ├── ExportedField.java
+│   │   │   │                   │   ├── JdbcSubjectDataProvider.java
+│   │   │   │                   │   ├── SubjectAccessExport.java
+│   │   │   │                   │   └── SubjectDataProvider.java
+│   │   │   │                   ├── audit/
+│   │   │   │                   │   ├── ActorResolver.java
+│   │   │   │                   │   ├── AsyncAuditSinkDecorator.java
+│   │   │   │                   │   ├── AuditAccessRecord.java
+│   │   │   │                   │   ├── AuditSink.java
+│   │   │   │                   │   ├── AuditSinkMetrics.java
+│   │   │   │                   │   ├── JdbcAuditSink.java
+│   │   │   │                   │   ├── PersonalDataAccessAdvisor.java
+│   │   │   │                   │   ├── Slf4jAuditSink.java
+│   │   │   │                   │   └── SubjectIdResolver.java
+│   │   │   │                   ├── autoconfig/
+│   │   │   │                   │   ├── GdprAutoConfiguration.java
+│   │   │   │                   │   └── GdprErasableScannerRegistrar.java
+│   │   │   │                   ├── erasure/
+│   │   │   │                   │   ├── crypto/
+│   │   │   │                   │   │   ├── AesGcmCryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShreddingErasureHandler.java
+│   │   │   │                   │   │   ├── InMemorySubjectKeyStore.java
+│   │   │   │                   │   │   ├── JdbcSubjectKeyStore.java
+│   │   │   │                   │   │   ├── SubjectKeyFactory.java
+│   │   │   │                   │   │   └── SubjectKeyStore.java
+│   │   │   │                   │   ├── forgettable/
+│   │   │   │                   │   │   ├── ForgettablePayloadErasureHandler.java
+│   │   │   │                   │   │   ├── ForgettablePayloadReference.java
+│   │   │   │                   │   │   ├── ForgettablePayloadResolver.java
+│   │   │   │                   │   │   ├── ForgettablePayloadStore.java
+│   │   │   │                   │   │   ├── InMemoryForgettablePayloadStore.java
+│   │   │   │                   │   │   └── JdbcForgettablePayloadStore.java
+│   │   │   │                   │   ├── CompositeSubjectErasureHandler.java
+│   │   │   │                   │   ├── ErasureHandler.java
+│   │   │   │                   │   ├── ErasureListener.java
+│   │   │   │                   │   ├── ErasureListenerException.java
+│   │   │   │                   │   ├── ErasureReport.java
+│   │   │   │                   │   ├── ErasureService.java
+│   │   │   │                   │   ├── JdbcErasureHandler.java
+│   │   │   │                   │   └── SubjectErasedEvent.java
+│   │   │   │                   ├── jdbc/
+│   │   │   │                   │   └── SqlIdentifiers.java
+│   │   │   │                   ├── logging/
+│   │   │   │                   │   ├── PiiMasker.java
+│   │   │   │                   │   └── PiiMaskingConverter.java
+│   │   │   │                   ├── retention/
+│   │   │   │                   │   ├── JdbcRetentionTarget.java
+│   │   │   │                   │   ├── RetentionScheduler.java
+│   │   │   │                   │   └── RetentionTarget.java
+│   │   │   │                   ├── web/
+│   │   │   │                   │   ├── GdprController.java
+│   │   │   │                   │   ├── GdprExceptionHandler.java
+│   │   │   │                   │   └── GdprSecurityWarning.java
+│   │   │   │                   └── GdprProperties.java
+│   │   │   └── resources/
+│   │   │       ├── db/
+│   │   │       │   ├── changelog/
+│   │   │       │   │   └── spring-gdpr-changelog.xml
+│   │   │       │   └── migration/
+│   │   │       │       ├── V1__gdpr_audit_access.sql
+│   │   │       │       ├── V2__gdpr_subject_key.sql
+│   │   │       │       └── V3__gdpr_forgettable_payload.sql
+│   │   │       └── META-INF/
+│   │   │           ├── spring/
+│   │   │           │   └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
+│   │   │           └── additional-spring-configuration-metadata.json
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── starter/
+│   │                           ├── access/
+│   │                           │   ├── AccessExportServiceTest.java
+│   │                           │   └── JdbcSubjectDataProviderTest.java
+│   │                           ├── audit/
+│   │                           │   ├── AsyncAuditSinkDecoratorTest.java
+│   │                           │   ├── AuditSinkMetricsTest.java
+│   │                           │   ├── JdbcAuditSinkPostgresIT.java
+│   │                           │   ├── JdbcAuditSinkTest.java
+│   │                           │   ├── LegalBasisMappingTest.java
+│   │                           │   └── PersonalDataAccessAdvisorTest.java
+│   │                           ├── autoconfig/
+│   │                           │   ├── declfixture/
+│   │                           │   │   ├── crypto/
+│   │                           │   │   │   └── CryptoShreddedEntity.java
+│   │                           │   │   ├── forgettable/
+│   │                           │   │   │   └── ForgettableEntity.java
+│   │                           │   │   └── legacy/
+│   │                           │   │       └── DeleteEntity.java
+│   │                           │   ├── DeclarativeErasureWiringTest.java
+│   │                           │   └── GdprAutoConfigurationTest.java
+│   │                           ├── erasure/
+│   │                           │   ├── crypto/
+│   │                           │   │   ├── AesGcmCryptoShredderTest.java
+│   │                           │   │   └── JdbcSubjectKeyStoreTest.java
+│   │                           │   ├── forgettable/
+│   │                           │   │   ├── CompositeSubjectErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadReferenceTest.java
+│   │                           │   │   ├── ForgettablePayloadResolverTest.java
+│   │                           │   │   ├── GdprPersonalDataStorageTest.java
+│   │                           │   │   ├── InMemoryForgettablePayloadStoreTest.java
+│   │                           │   │   └── JdbcForgettablePayloadStoreTest.java
+│   │                           │   ├── CryptoShreddingErasureTest.java
+│   │                           │   ├── ErasureListenerTest.java
+│   │                           │   ├── ErasureServiceTest.java
+│   │                           │   └── JdbcErasureHandlerTest.java
+│   │                           ├── logging/
+│   │                           │   ├── PiiMaskerTest.java
+│   │                           │   └── PiiMaskingConverterTest.java
+│   │                           ├── retention/
+│   │                           │   ├── JdbcRetentionTargetTest.java
+│   │                           │   └── RetentionSchedulerTest.java
+│   │                           └── web/
+│   │                               ├── GdprControllerTest.java
+│   │                               └── GdprSecurityWarningTest.java
+│   └── pom.xml
+├── spring-gdpr-starter-test/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   └── java/
+│   │   │       └── com/
+│   │   │           └── iambilotta/
+│   │   │               └── gdpr/
+│   │   │                   └── demo/
+│   │   │                       ├── Customer.java
+│   │   │                       ├── CustomerErasureHandler.java
+│   │   │                       ├── CustomerRepository.java
+│   │   │                       └── DemoApplication.java
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── demo/
+│   │                           └── GdprIntegrationTest.java
+│   └── pom.xml
+├── .editorconfig
+├── .gitignore
+├── CHANGELOG.md
+├── CITATION.cff
+├── CLAUDE.md
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING.md
+├── jitpack.yml
+├── LICENSE
+├── Makefile
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+├── README.md
+├── SECURITY.md
+├── SUPPORT.md
+└── tracegate.toml
+```

--- a/spring-gdpr-starter-test/_generated/todo.md
+++ b/spring-gdpr-starter-test/_generated/todo.md
@@ -1,0 +1,7 @@
+# Tech debt inventory — spring-gdpr-starter-test (as-is)
+
+Auto-generated. Every `TODO` / `FIXME` / `XXX` / `HACK` marker plus every `@Deprecated` in the authored sources is listed below, with `git blame` author and age in days. The purpose is **visibility**: nothing here is automatically blocking, but a marker that ages past 90 days is usually either done-by-other-means (delete the marker) or stale debt that should become an ADR or an issue.
+
+**Total markers**: 0
+
+✓ Zero markers in the authored sources right now.

--- a/spring-gdpr-starter/_generated/MANIFEST.md
+++ b/spring-gdpr-starter/_generated/MANIFEST.md
@@ -1,0 +1,40 @@
+# MANIFEST — spring-gdpr-starter auto-generated docs
+
+Read this **first** in a fresh session. Every doc below is regenerated from the code (or tests / migrations / properties / pom) on every commit; the markdown is never the source of truth. Path-only links so any tool that opens the manifest can lazy-load.
+
+## Map
+
+- [`structure.md`](./structure.md) — convention-driven repository tree (git-tracked skeleton) — read first to orient
+
+## Scope & roadmap
+
+- [`requirements.md`](./requirements.md) — tests-as-requirements catalog (FR/NFR/INV/CON/E2E), 100% spec javadoc
+- [`requirements-by-us.md`](./requirements-by-us.md) — tests grouped per User Story with AC coverage gate
+
+## Architecture
+
+- [`modules.md`](./modules.md) — Modulith canvas + cross-module dependency graph + cycle detection
+- [`modules-graph.md`](./modules-graph.md) — Mermaid module-dependency graph (cycles highlighted), renders inline on GitHub/intranet
+- [`domain-model.md`](./domain-model.md) — Mermaid class diagram of the domain: records, sealed hierarchies, enums
+- [`ports.md`](./ports.md) — hexagonal ports → adapters matrix
+- [`templates.md`](./templates.md) — JTE template tree (params + include graph)
+
+## Behavior
+
+- [`http-endpoints.md`](./http-endpoints.md) — every HTTP route with javadoc + contract reference
+- [`state-machine.md`](./state-machine.md) — Mermaid stateDiagram-v2 from a declared transition table (when present)
+
+## State
+
+- [`config.md`](./config.md) — application properties per profile + Java usages
+- [`dependencies.md`](./dependencies.md) — Maven + npm + Python dependency tree
+
+## Quality & debt
+
+- [`coverage.md`](./coverage.md) — JaCoCo per-file coverage with full file list (incl. 0% files)
+- [`todo.md`](./todo.md) — TODO/FIXME/HACK/@Deprecated inventory with git blame
+- [`adr-index.md`](./adr-index.md) — Architecture Decision Record index + auto-detected ADR candidates
+
+---
+
+**Convention**: `_generated/` is gitignored at the repo root (pattern `**/_generated/`) but the tracked `_generated/` of a documented app IS the docs. Pre-commit regenerates everything; never hand-edit a file in this directory.

--- a/spring-gdpr-starter/_generated/adr-index.md
+++ b/spring-gdpr-starter/_generated/adr-index.md
@@ -1,0 +1,15 @@
+# ADR index — spring-gdpr-starter (as-is)
+
+Auto-generated from `apps/gest/decisions/NNNN-*.md`. Title comes from the H1; status from a `Status: ...` line in the body; supported user stories from `US-NNN-slug` citations anywhere in the file. The 'Candidates' section is a heuristic scan of the codebase for load-bearing decisions (feature flags, invariants, contracts, projections) that have NO matching ADR yet — surface, don't autofix.
+
+**Total ADRs**: 0
+
+_No ADR files found under `apps/gest/decisions/`._
+
+## Candidates (auto-detected, 1 signals)
+
+Heuristic. Each signal usually warrants an ADR (a feature flag, an invariant, a contract, a projection design choice are all decisions you'll want to defend in 6 months). Open the file, decide if it's already covered by an existing ADR, otherwise consider writing a new one.
+
+### conditional bean wiring (1)
+
+- `spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java` — @Conditional* present: feature flag / runtime branch — usually load-bearing

--- a/spring-gdpr-starter/_generated/coverage.md
+++ b/spring-gdpr-starter/_generated/coverage.md
@@ -1,0 +1,73 @@
+# Coverage — spring-gdpr-starter (as-is)
+
+⚠ **No JaCoCo CSV found** at `apps/gest/target/site/jacoco/jacoco.csv`. Run `make coverage` (alias for `./mvnw test` + regen) and try again. Without the CSV every file below shows 0% — that's the absence of data, not a result.
+
+**Files**: 47 · **Overall line coverage**: 0.0% (0/0)
+
+## By package
+
+| Package | Files | Lines covered | Line % | Branch % |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr.starter` | 1 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.access` | 5 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.audit` | 9 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.autoconfig` | 2 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.erasure` | 8 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.erasure.crypto` | 7 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.erasure.forgettable` | 6 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.jdbc` | 1 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.logging` | 2 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.retention` | 3 | 0/0 | 0.0% | 0.0% |
+| `com.iambilotta.gdpr.starter.web` | 3 | 0/0 | 0.0% | 0.0% |
+
+## Per file (all production sources)
+
+| File | Lines | Line % | Branch % | Methods |
+|---|---|---|---|---|
+| `com/iambilotta/gdpr/starter/GdprProperties.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/access/AccessExportService.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/access/ExportedField.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/access/JdbcSubjectDataProvider.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/access/SubjectAccessExport.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/access/SubjectDataProvider.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/ActorResolver.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/AsyncAuditSinkDecorator.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/AuditAccessRecord.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/AuditSink.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/AuditSinkMetrics.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/JdbcAuditSink.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/PersonalDataAccessAdvisor.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/Slf4jAuditSink.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/audit/SubjectIdResolver.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/autoconfig/GdprErasableScannerRegistrar.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/CompositeSubjectErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/ErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/ErasureListener.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/ErasureListenerException.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/ErasureReport.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/ErasureService.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/JdbcErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/SubjectErasedEvent.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/AesGcmCryptoShredder.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/CryptoShredder.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/CryptoShreddingErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/InMemorySubjectKeyStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/JdbcSubjectKeyStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/SubjectKeyFactory.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/crypto/SubjectKeyStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/ForgettablePayloadErasureHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/ForgettablePayloadReference.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/ForgettablePayloadResolver.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/ForgettablePayloadStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/InMemoryForgettablePayloadStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStore.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/jdbc/SqlIdentifiers.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/logging/PiiMasker.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/logging/PiiMaskingConverter.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/retention/JdbcRetentionTarget.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/retention/RetentionScheduler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/retention/RetentionTarget.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/web/GdprController.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/web/GdprExceptionHandler.java` | — | — | — | 0/0 |
+| `com/iambilotta/gdpr/starter/web/GdprSecurityWarning.java` | — | — | — | 0/0 |

--- a/spring-gdpr-starter/_generated/dependencies.md
+++ b/spring-gdpr-starter/_generated/dependencies.md
@@ -1,0 +1,30 @@
+# Dependencies — spring-gdpr-starter (as-is)
+
+Auto-generated from `pom.xml` (Maven), `frontend/package.json` + `e2e/package.json` (npm), and `scripts/requirements.txt` (Python). Empty version = inherited from Spring Boot parent BOM. Pre-commit refreshes this; if you bump a version anywhere, the diff lands here too.
+
+**Total**: 15 (maven=14, maven (parent)=1)
+
+## maven (14)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.h2database` | `h2` | `(from parent / bom)` | `test` | `spring-gdpr-starter/pom.xml` |
+| `com.iambilotta.gdpr` | `spring-gdpr-annotations` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `io.micrometer` | `micrometer-core` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.postgresql` | `postgresql` | `(from parent / bom)` | `test` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-autoconfigure-processor` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-configuration-processor` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-aspectj` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-jdbc` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-test` | `(from parent / bom)` | `test` | `spring-gdpr-starter/pom.xml` |
+| `org.springframework.boot` | `spring-boot-starter-web` | `(from parent / bom)` | `compile` | `spring-gdpr-starter/pom.xml` |
+| `org.testcontainers` | `junit-jupiter` | `1.21.4` | `test` | `spring-gdpr-starter/pom.xml` |
+| `org.testcontainers` | `postgresql` | `1.21.4` | `test` | `spring-gdpr-starter/pom.xml` |
+| `org.testcontainers` | `testcontainers` | `2.0.5` | `test` | `spring-gdpr-starter/pom.xml` |
+
+## maven (parent) (1)
+
+| Group | Name | Version | Scope | Source |
+|---|---|---|---|---|
+| `com.iambilotta.gdpr` | `spring-gdpr-parent` | `2.0.0` | `parent` | `spring-gdpr-starter/pom.xml` |

--- a/spring-gdpr-starter/_generated/domain-model.md
+++ b/spring-gdpr-starter/_generated/domain-model.md
@@ -1,0 +1,9 @@
+# Domain model — spring-gdpr-starter (as-is)
+
+Auto-generated from every type under a `**/domain/**` package, parsed via tree-sitter. Records become classes with their components as fields; a `sealed interface` and its `permits` list become an inheritance hierarchy (`<|--`); enums are tagged `<<enumeration>>` with their constants. This is the shape of the domain the way the code declares it — invalid states made unrepresentable show up as the variant payloads. Run `make code-docs` to regenerate; the source of truth is the code, never this markdown.
+
+**Types**: 0 (0 records · 0 sealed interfaces · 0 enums)
+
+```mermaid
+classDiagram
+```

--- a/spring-gdpr-starter/_generated/modules-graph.md
+++ b/spring-gdpr-starter/_generated/modules-graph.md
@@ -1,0 +1,30 @@
+# Module map — spring-gdpr-starter (as-is)
+
+Auto-generated from the same data as `modules.md`: each top-level package under `com.iambilotta.gdpr.starter` is a module, the arrows are the cross-module `import` dependencies. A cycle is a Modulith boundary violation (highlighted below). Rendered as Mermaid so it shows inline on GitHub and the intranet. Run `make code-docs`.
+
+✓ No module cycles.
+
+```mermaid
+flowchart TD
+    _root_["(root)<br/>(1 files)"]
+    access["access<br/>(5 files)"]
+    audit["audit<br/>(9 files)"]
+    autoconfig["autoconfig<br/>(2 files)"]
+    erasure["erasure<br/>(21 files)"]
+    jdbc["jdbc<br/>(1 files)"]
+    logging["logging<br/>(2 files)"]
+    retention["retention<br/>(3 files)"]
+    web["web<br/>(3 files)"]
+    access --> jdbc
+    autoconfig --> access
+    autoconfig --> audit
+    autoconfig --> erasure
+    autoconfig --> retention
+    autoconfig --> web
+    erasure --> audit
+    erasure --> jdbc
+    retention --> jdbc
+    web --> access
+    web --> audit
+    web --> erasure
+```

--- a/spring-gdpr-starter/_generated/requirements-by-us.md
+++ b/spring-gdpr-starter/_generated/requirements-by-us.md
@@ -4,8 +4,8 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
 
 ## Coverage
 
-- Total tests scanned: **107**
-- Tests linked to a User Story: **72**
+- Total tests scanned: **111**
+- Tests linked to a User Story: **76**
 - Tests without `@spec.us` (implementation detail): **35**
 - User Stories declared in PRODUCT.md: **0**
 - User Stories with at least one linked test: **0**
@@ -112,6 +112,8 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
   - **Then**: a tombstone is recorded so the subject can never be populated afterwards
 - `FR-erasure.forgettable.JdbcForgettablePayloadStore#erasedSubjectCannotHaveAPayloadReWritten`
   - **Then**: the put is refused (the tombstone forbids silently re-creating an erased subject)
+- `FR-erasure.forgettable.JdbcForgettablePayloadStore#handlesLargeFreetextPayloadBeyondOldVarcharLimit`
+  - **Then**: the full value round-trips without truncation (payload_value is TEXT, unbounded)
 - `FR-erasure.forgettable.JdbcForgettablePayloadStore#putIsAnUpsert`
   - **Then**: resolve returns the latest value (last-writer-wins upsert)
 - `FR-erasure.forgettable.JdbcForgettablePayloadStore#putsAndResolvesAValue`
@@ -120,6 +122,12 @@ Auto-generated companion to `requirements.md`. Tests link to a User Story via th
   - **Then**: construction fails fast before any SQL is built (injection-safe)
 - `FR-erasure.forgettable.JdbcForgettablePayloadStore#resolveOfMissingFieldIsEmpty`
   - **Then**: resolve returns empty (fail-closed: a missing value is never a partial/placeholder)
+- `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#erasureWritesTombstoneAndDeletesFieldsOnPostgres`
+  - **Then**: the tombstone is written using the plain '__erased__' reserved key (no NUL byte) and every resolved field is empty afterwards
+- `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#largeFreetextPayloadRoundTripsOnPostgres`
+  - **Then**: the full value round-trips without truncation on Postgres
+- `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#putAndResolveAgainstMigratedPostgresSchema`
+  - **Then**: the store works against the migrated schema (migration is Postgres-compatible)
 
 ## `REQ-GDPR-023`  _(unknown to PRODUCT.md)_
 

--- a/spring-gdpr-starter/_generated/requirements.json
+++ b/spring-gdpr-starter/_generated/requirements.json
@@ -5,10 +5,10 @@
   },
   "label": "spring-gdpr-starter",
   "coverage": {
-    "total": 107,
-    "with_complete_spec": 72,
+    "total": 111,
+    "with_complete_spec": 76,
     "by_category": {
-      "FR": 107
+      "FR": 111
     }
   },
   "requirements": [
@@ -1526,6 +1526,23 @@
       }
     },
     {
+      "id": "FR-erasure.forgettable.JdbcForgettablePayloadStore#handlesLargeFreetextPayloadBeyondOldVarcharLimit",
+      "category": "FR",
+      "module": "erasure.forgettable",
+      "unit": "JdbcForgettablePayloadStore",
+      "method": "handlesLargeFreetextPayloadBeyondOldVarcharLimit",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java",
+      "spec": {
+        "given": "a free-text PII value longer than 4096 characters (the old VARCHAR cap)",
+        "when": "that value is stored and resolved",
+        "then": "the full value round-trips without truncation (payload_value is TEXT, unbounded)",
+        "adr": "ADR-0010",
+        "us": "REQ-GDPR-022",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
       "id": "FR-erasure.forgettable.JdbcForgettablePayloadStore#putIsAnUpsert",
       "category": "FR",
       "module": "erasure.forgettable",
@@ -1587,6 +1604,57 @@
         "given": "a subject without a value for a given field",
         "when": "that field is resolved",
         "then": "resolve returns empty (fail-closed: a missing value is never a partial/placeholder)",
+        "adr": "ADR-0010",
+        "us": "REQ-GDPR-022",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#erasureWritesTombstoneAndDeletesFieldsOnPostgres",
+      "category": "FR",
+      "module": "erasure.forgettable",
+      "unit": "JdbcForgettablePayloadStorePostgres",
+      "method": "erasureWritesTombstoneAndDeletesFieldsOnPostgres",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java",
+      "spec": {
+        "given": "a subject with fields stored on Postgres",
+        "when": "the subject is erased",
+        "then": "the tombstone is written using the plain '__erased__' reserved key (no NUL byte) and every resolved field is empty afterwards",
+        "adr": "ADR-0010",
+        "us": "REQ-GDPR-022",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#largeFreetextPayloadRoundTripsOnPostgres",
+      "category": "FR",
+      "module": "erasure.forgettable",
+      "unit": "JdbcForgettablePayloadStorePostgres",
+      "method": "largeFreetextPayloadRoundTripsOnPostgres",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java",
+      "spec": {
+        "given": "the V3 Flyway migration applied to PostgreSQL (payload_value is TEXT, not VARCHAR)",
+        "when": "a free-text value longer than 4096 characters is stored and resolved",
+        "then": "the full value round-trips without truncation on Postgres",
+        "adr": "ADR-0010",
+        "us": "REQ-GDPR-022",
+        "ac": "",
+        "complete": true
+      }
+    },
+    {
+      "id": "FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#putAndResolveAgainstMigratedPostgresSchema",
+      "category": "FR",
+      "module": "erasure.forgettable",
+      "unit": "JdbcForgettablePayloadStorePostgres",
+      "method": "putAndResolveAgainstMigratedPostgresSchema",
+      "file": "spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java",
+      "spec": {
+        "given": "the V3 Flyway migration applied to a real PostgreSQL 16 database",
+        "when": "a value is put and resolved",
+        "then": "the store works against the migrated schema (migration is Postgres-compatible)",
         "adr": "ADR-0010",
         "us": "REQ-GDPR-022",
         "ac": "",

--- a/spring-gdpr-starter/_generated/requirements.md
+++ b/spring-gdpr-starter/_generated/requirements.md
@@ -2,13 +2,13 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 
-- Total tests scanned: **107**
-- With complete spec javadoc: **72** (67%)
-- FR: 107
+- Total tests scanned: **111**
+- With complete spec javadoc: **76** (68%)
+- FR: 111
 
 ## Module `access`
 
@@ -694,6 +694,15 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 - **User Story**: REQ-GDPR-022
 - **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java`
 
+#### `FR-erasure.forgettable.JdbcForgettablePayloadStore#handlesLargeFreetextPayloadBeyondOldVarcharLimit`
+
+- **Given**: a free-text PII value longer than 4096 characters (the old VARCHAR cap)
+- **When**: that value is stored and resolved
+- **Then**: the full value round-trips without truncation (payload_value is TEXT, unbounded)
+- **ADR**: ADR-0010
+- **User Story**: REQ-GDPR-022
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java`
+
 #### `FR-erasure.forgettable.JdbcForgettablePayloadStore#putIsAnUpsert`
 
 - **Given**: an existing value for (subject, field)
@@ -729,6 +738,33 @@ Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the tes
 - **ADR**: ADR-0010
 - **User Story**: REQ-GDPR-022
 - **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java`
+
+#### `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#erasureWritesTombstoneAndDeletesFieldsOnPostgres`
+
+- **Given**: a subject with fields stored on Postgres
+- **When**: the subject is erased
+- **Then**: the tombstone is written using the plain '__erased__' reserved key (no NUL byte) and every resolved field is empty afterwards
+- **ADR**: ADR-0010
+- **User Story**: REQ-GDPR-022
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java`
+
+#### `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#largeFreetextPayloadRoundTripsOnPostgres`
+
+- **Given**: the V3 Flyway migration applied to PostgreSQL (payload_value is TEXT, not VARCHAR)
+- **When**: a free-text value longer than 4096 characters is stored and resolved
+- **Then**: the full value round-trips without truncation on Postgres
+- **ADR**: ADR-0010
+- **User Story**: REQ-GDPR-022
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java`
+
+#### `FR-erasure.forgettable.JdbcForgettablePayloadStorePostgres#putAndResolveAgainstMigratedPostgresSchema`
+
+- **Given**: the V3 Flyway migration applied to a real PostgreSQL 16 database
+- **When**: a value is put and resolved
+- **Then**: the store works against the migrated schema (migration is Postgres-compatible)
+- **ADR**: ADR-0010
+- **User Story**: REQ-GDPR-022
+- **File**: `spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java`
 
 
 ## Module `logging`

--- a/spring-gdpr-starter/_generated/requirements.md
+++ b/spring-gdpr-starter/_generated/requirements.md
@@ -2,7 +2,7 @@
 
 Auto-generated from test sources by tracegate. Do NOT edit by hand: edit the test javadoc / docstring instead and rerun. Single source of truth is the test code.
 
-**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; frontend vitest tests join as **FE**; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
+**Convention**: category from the test name (`*Test`=FR, `*NfrTest`=NFR, `*InvariantTest`=INV, `*ContractTest`=CON; Python file markers `*invariant*`/`*nfr*`/`*contract*` map the same way; Playwright E2E tests join as **E2E**). Spec from doc-comment tags `@spec.given` / `@spec.when` / `@spec.then` (plus optional `@spec.adr` / `@spec.us`). Tests without a complete spec are listed with `(spec missing)` so they're visible and lintable.
 
 ## Coverage
 

--- a/spring-gdpr-starter/_generated/state-machine.md
+++ b/spring-gdpr-starter/_generated/state-machine.md
@@ -1,0 +1,5 @@
+# State machine — spring-gdpr-starter (as-is)
+
+Auto-generated from every DECLARED transition table (`*Transition` enum under `**/domain/**` whose constants carry their resulting state). The state machine is DATA, so this `stateDiagram-v2` is a pure function of the AST — every arc is derived, never hand-drawn. A transition with no single target state (a generic edit, a removal) is listed below the diagram, not drawn as an arc. Run `make code-docs`; the source of truth is the transition table in the code, never this markdown.
+
+_No declared transition table found. Declare the state machine as data — an enum `<Aggregate>Transition` under a `domain` package whose constants name their resulting state — and tracegate renders the diagram from it (no hand-drawing)._

--- a/spring-gdpr-starter/_generated/structure.md
+++ b/spring-gdpr-starter/_generated/structure.md
@@ -1,0 +1,331 @@
+# Structure — `spring-gdpr`
+
+Convention-driven skeleton of the repository: the git-tracked files (respecting `.gitignore`, so no `node_modules` / `target` / build output), rendered as a tree. A single readable snapshot of where everything lives, for a human or an agent orienting in a fresh session. Regenerated on every commit like every `_generated` doc; the source of truth is the filesystem, never this markdown.
+
+_194 tracked paths._
+
+```
+spring-gdpr/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug.md
+│   │   └── feature.md
+│   ├── workflows/
+│   │   ├── ci.yml
+│   │   └── codeql.yml
+│   ├── dependabot.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── pull_request_template.md
+├── .mvn/
+│   └── wrapper/
+│       └── maven-wrapper.properties
+├── docs/
+│   ├── adr/
+│   │   ├── 0000-template.md
+│   │   ├── 0001-annotations-as-source-of-truth.md
+│   │   ├── 0002-async-audit-sink-default.md
+│   │   ├── 0003-build-time-and-runtime-as-two-products.md
+│   │   ├── 0004-erasure-handler-orchestration.md
+│   │   ├── 0005-retention-via-spring-scheduled.md
+│   │   ├── 0006-typed-class-on-spi.md
+│   │   ├── 0007-subjectidfield-is-documentation-only.md
+│   │   ├── 0008-consent-and-portability-deferred.md
+│   │   ├── 0009-append-only-erasure-crypto-shredding.md
+│   │   ├── 0010-forgettable-payload-primary-pattern.md
+│   │   └── README.md
+│   ├── articles/
+│   │   └── 01-gdpr-compliance-by-annotation.md
+│   ├── requirements/
+│   │   └── gdpr.requirements.md
+│   └── DX-review.md
+├── examples/
+│   └── quickstart-postgres/
+│       ├── _generated/
+│       │   ├── config.md
+│       │   ├── http-endpoints.md
+│       │   ├── modules.md
+│       │   ├── ports.md
+│       │   ├── requirements-by-us.md
+│       │   ├── requirements.json
+│       │   ├── requirements.md
+│       │   └── templates.md
+│       ├── src/
+│       │   ├── main/
+│       │   │   ├── java/
+│       │   │   │   └── com/
+│       │   │   │       └── example/
+│       │   │   │           └── gdprdemo/
+│       │   │   │               ├── Customer.java
+│       │   │   │               ├── CustomerController.java
+│       │   │   │               ├── CustomerErasureHandler.java
+│       │   │   │               ├── CustomerRepository.java
+│       │   │   │               ├── GdprExportConfig.java
+│       │   │   │               ├── QuickstartApplication.java
+│       │   │   │               └── SecurityConfig.java
+│       │   │   └── resources/
+│       │   │       ├── db/
+│       │   │       │   └── migration/
+│       │   │       │       ├── V1__gdpr_audit_access.sql
+│       │   │       │       └── V2__customers_table.sql
+│       │   │       ├── application.yml
+│       │   │       └── logback-spring.xml
+│       │   └── test/
+│       │       └── java/
+│       │           └── com/
+│       │               └── example/
+│       │                   └── gdprdemo/
+│       │                       └── QuickstartE2ETest.java
+│       ├── docker-compose.yml
+│       ├── pom.xml
+│       └── README.md
+├── spring-gdpr-annotations/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── annotations/
+│   │                           ├── GdprDataSubjects.java
+│   │                           ├── GdprErasable.java
+│   │                           ├── GdprLegalBasis.java
+│   │                           ├── GdprPersonalData.java
+│   │                           ├── GdprRetention.java
+│   │                           └── package-info.java
+│   └── pom.xml
+├── spring-gdpr-benchmark/
+│   ├── results/
+│   │   └── 2026-05-02-jdk25-corretto.json
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── benchmark/
+│   │                           └── AuditSinkBenchmark.java
+│   ├── pom.xml
+│   └── README.md
+├── spring-gdpr-maven-plugin/
+│   ├── src/
+│   │   └── main/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── plugin/
+│   │                           ├── AbstractGdprMojo.java
+│   │                           ├── DpiaMojo.java
+│   │                           ├── RopaMojo.java
+│   │                           └── VerifyMojo.java
+│   └── pom.xml
+├── spring-gdpr-processor/
+│   ├── _generated/
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   └── requirements.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── processor/
+│   │   │   │                   └── GdprAnnotationProcessor.java
+│   │   │   └── resources/
+│   │   │       └── META-INF/
+│   │   │           └── services/
+│   │   │               └── javax.annotation.processing.Processor
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── processor/
+│   │                           └── ProcessingRecordCategoryTest.java
+│   └── pom.xml
+├── spring-gdpr-starter/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/
+│   │   │   │   └── com/
+│   │   │   │       └── iambilotta/
+│   │   │   │           └── gdpr/
+│   │   │   │               └── starter/
+│   │   │   │                   ├── access/
+│   │   │   │                   │   ├── AccessExportService.java
+│   │   │   │                   │   ├── ExportedField.java
+│   │   │   │                   │   ├── JdbcSubjectDataProvider.java
+│   │   │   │                   │   ├── SubjectAccessExport.java
+│   │   │   │                   │   └── SubjectDataProvider.java
+│   │   │   │                   ├── audit/
+│   │   │   │                   │   ├── ActorResolver.java
+│   │   │   │                   │   ├── AsyncAuditSinkDecorator.java
+│   │   │   │                   │   ├── AuditAccessRecord.java
+│   │   │   │                   │   ├── AuditSink.java
+│   │   │   │                   │   ├── AuditSinkMetrics.java
+│   │   │   │                   │   ├── JdbcAuditSink.java
+│   │   │   │                   │   ├── PersonalDataAccessAdvisor.java
+│   │   │   │                   │   ├── Slf4jAuditSink.java
+│   │   │   │                   │   └── SubjectIdResolver.java
+│   │   │   │                   ├── autoconfig/
+│   │   │   │                   │   ├── GdprAutoConfiguration.java
+│   │   │   │                   │   └── GdprErasableScannerRegistrar.java
+│   │   │   │                   ├── erasure/
+│   │   │   │                   │   ├── crypto/
+│   │   │   │                   │   │   ├── AesGcmCryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShredder.java
+│   │   │   │                   │   │   ├── CryptoShreddingErasureHandler.java
+│   │   │   │                   │   │   ├── InMemorySubjectKeyStore.java
+│   │   │   │                   │   │   ├── JdbcSubjectKeyStore.java
+│   │   │   │                   │   │   ├── SubjectKeyFactory.java
+│   │   │   │                   │   │   └── SubjectKeyStore.java
+│   │   │   │                   │   ├── forgettable/
+│   │   │   │                   │   │   ├── ForgettablePayloadErasureHandler.java
+│   │   │   │                   │   │   ├── ForgettablePayloadReference.java
+│   │   │   │                   │   │   ├── ForgettablePayloadResolver.java
+│   │   │   │                   │   │   ├── ForgettablePayloadStore.java
+│   │   │   │                   │   │   ├── InMemoryForgettablePayloadStore.java
+│   │   │   │                   │   │   └── JdbcForgettablePayloadStore.java
+│   │   │   │                   │   ├── CompositeSubjectErasureHandler.java
+│   │   │   │                   │   ├── ErasureHandler.java
+│   │   │   │                   │   ├── ErasureListener.java
+│   │   │   │                   │   ├── ErasureListenerException.java
+│   │   │   │                   │   ├── ErasureReport.java
+│   │   │   │                   │   ├── ErasureService.java
+│   │   │   │                   │   ├── JdbcErasureHandler.java
+│   │   │   │                   │   └── SubjectErasedEvent.java
+│   │   │   │                   ├── jdbc/
+│   │   │   │                   │   └── SqlIdentifiers.java
+│   │   │   │                   ├── logging/
+│   │   │   │                   │   ├── PiiMasker.java
+│   │   │   │                   │   └── PiiMaskingConverter.java
+│   │   │   │                   ├── retention/
+│   │   │   │                   │   ├── JdbcRetentionTarget.java
+│   │   │   │                   │   ├── RetentionScheduler.java
+│   │   │   │                   │   └── RetentionTarget.java
+│   │   │   │                   ├── web/
+│   │   │   │                   │   ├── GdprController.java
+│   │   │   │                   │   ├── GdprExceptionHandler.java
+│   │   │   │                   │   └── GdprSecurityWarning.java
+│   │   │   │                   └── GdprProperties.java
+│   │   │   └── resources/
+│   │   │       ├── db/
+│   │   │       │   ├── changelog/
+│   │   │       │   │   └── spring-gdpr-changelog.xml
+│   │   │       │   └── migration/
+│   │   │       │       ├── V1__gdpr_audit_access.sql
+│   │   │       │       ├── V2__gdpr_subject_key.sql
+│   │   │       │       └── V3__gdpr_forgettable_payload.sql
+│   │   │       └── META-INF/
+│   │   │           ├── spring/
+│   │   │           │   └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
+│   │   │           └── additional-spring-configuration-metadata.json
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── starter/
+│   │                           ├── access/
+│   │                           │   ├── AccessExportServiceTest.java
+│   │                           │   └── JdbcSubjectDataProviderTest.java
+│   │                           ├── audit/
+│   │                           │   ├── AsyncAuditSinkDecoratorTest.java
+│   │                           │   ├── AuditSinkMetricsTest.java
+│   │                           │   ├── JdbcAuditSinkPostgresIT.java
+│   │                           │   ├── JdbcAuditSinkTest.java
+│   │                           │   ├── LegalBasisMappingTest.java
+│   │                           │   └── PersonalDataAccessAdvisorTest.java
+│   │                           ├── autoconfig/
+│   │                           │   ├── declfixture/
+│   │                           │   │   ├── crypto/
+│   │                           │   │   │   └── CryptoShreddedEntity.java
+│   │                           │   │   ├── forgettable/
+│   │                           │   │   │   └── ForgettableEntity.java
+│   │                           │   │   └── legacy/
+│   │                           │   │       └── DeleteEntity.java
+│   │                           │   ├── DeclarativeErasureWiringTest.java
+│   │                           │   └── GdprAutoConfigurationTest.java
+│   │                           ├── erasure/
+│   │                           │   ├── crypto/
+│   │                           │   │   ├── AesGcmCryptoShredderTest.java
+│   │                           │   │   └── JdbcSubjectKeyStoreTest.java
+│   │                           │   ├── forgettable/
+│   │                           │   │   ├── CompositeSubjectErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadErasureHandlerTest.java
+│   │                           │   │   ├── ForgettablePayloadReferenceTest.java
+│   │                           │   │   ├── ForgettablePayloadResolverTest.java
+│   │                           │   │   ├── GdprPersonalDataStorageTest.java
+│   │                           │   │   ├── InMemoryForgettablePayloadStoreTest.java
+│   │                           │   │   └── JdbcForgettablePayloadStoreTest.java
+│   │                           │   ├── CryptoShreddingErasureTest.java
+│   │                           │   ├── ErasureListenerTest.java
+│   │                           │   ├── ErasureServiceTest.java
+│   │                           │   └── JdbcErasureHandlerTest.java
+│   │                           ├── logging/
+│   │                           │   ├── PiiMaskerTest.java
+│   │                           │   └── PiiMaskingConverterTest.java
+│   │                           ├── retention/
+│   │                           │   ├── JdbcRetentionTargetTest.java
+│   │                           │   └── RetentionSchedulerTest.java
+│   │                           └── web/
+│   │                               ├── GdprControllerTest.java
+│   │                               └── GdprSecurityWarningTest.java
+│   └── pom.xml
+├── spring-gdpr-starter-test/
+│   ├── _generated/
+│   │   ├── config.md
+│   │   ├── http-endpoints.md
+│   │   ├── modules.md
+│   │   ├── ports.md
+│   │   ├── requirements-by-us.md
+│   │   ├── requirements.json
+│   │   ├── requirements.md
+│   │   └── templates.md
+│   ├── src/
+│   │   ├── main/
+│   │   │   └── java/
+│   │   │       └── com/
+│   │   │           └── iambilotta/
+│   │   │               └── gdpr/
+│   │   │                   └── demo/
+│   │   │                       ├── Customer.java
+│   │   │                       ├── CustomerErasureHandler.java
+│   │   │                       ├── CustomerRepository.java
+│   │   │                       └── DemoApplication.java
+│   │   └── test/
+│   │       └── java/
+│   │           └── com/
+│   │               └── iambilotta/
+│   │                   └── gdpr/
+│   │                       └── demo/
+│   │                           └── GdprIntegrationTest.java
+│   └── pom.xml
+├── .editorconfig
+├── .gitignore
+├── CHANGELOG.md
+├── CITATION.cff
+├── CLAUDE.md
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING.md
+├── jitpack.yml
+├── LICENSE
+├── Makefile
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+├── README.md
+├── SECURITY.md
+├── SUPPORT.md
+└── tracegate.toml
+```

--- a/spring-gdpr-starter/_generated/todo.md
+++ b/spring-gdpr-starter/_generated/todo.md
@@ -1,0 +1,7 @@
+# Tech debt inventory — spring-gdpr-starter (as-is)
+
+Auto-generated. Every `TODO` / `FIXME` / `XXX` / `HACK` marker plus every `@Deprecated` in the authored sources is listed below, with `git blame` author and age in days. The purpose is **visibility**: nothing here is automatically blocking, but a marker that ages past 90 days is usually either done-by-other-means (delete the marker) or stale debt that should become an ADR or an issue.
+
+**Total markers**: 0
+
+✓ Zero markers in the authored sources right now.

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStore.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStore.java
@@ -52,10 +52,12 @@ public final class JdbcForgettablePayloadStore implements ForgettablePayloadStor
     }
 
     public void bootstrapSchema() {
+        // TEXT (unbounded) mirrors V3__gdpr_forgettable_payload.sql: the primary use case is
+        // free-text PII (operator notes, comments) that can easily exceed 4096 characters.
         jdbc.execute("CREATE TABLE IF NOT EXISTS " + table + " ("
                 + "subject_id VARCHAR(255) NOT NULL, "
                 + "field_key  VARCHAR(255) NOT NULL, "
-                + "payload_value VARCHAR(4096), "
+                + "payload_value TEXT, "
                 + "updated_at TIMESTAMP NOT NULL, "
                 + "erased_at  TIMESTAMP, "
                 + "PRIMARY KEY (subject_id, field_key)"

--- a/spring-gdpr-starter/src/main/resources/db/migration/V3__gdpr_forgettable_payload.sql
+++ b/spring-gdpr-starter/src/main/resources/db/migration/V3__gdpr_forgettable_payload.sql
@@ -1,7 +1,7 @@
 -- spring-gdpr forgettable-payload external PII store (ADR-0010, REQ-GDPR-022).
 -- Flyway-compatible migration. Apply via Flyway, Liquibase, or your own runner.
 -- Tested against PostgreSQL 14+, MariaDB 10.6+, MySQL 8.0+, H2.
--- Oracle: replace IF NOT EXISTS and adjust VARCHAR sizes (4000-byte limit) as needed.
+-- Oracle: replace IF NOT EXISTS and adjust types (CLOB for TEXT) as needed.
 
 -- The mutable external store for personal-data fields marked storage = FORGETTABLE_PAYLOAD.
 -- The domain object / event carries only a ForgettablePayloadReference (subject_id + field_key);
@@ -13,17 +13,21 @@
 -- personal data (Recital 26, EDPB 01/2025). Crypto-shredding (V2) stays the narrow exception for an
 -- immutable event that must legally carry the value inline.
 --
--- TOMBSTONE: the per-subject erased state is a reserved row (field_key = ' __erased__',
+-- TOMBSTONE: the per-subject erased state is a reserved row (field_key = '__erased__',
 -- erased_at non-NULL). It is what makes the erasure a recorded fact and stops a later write from
 -- silently re-creating an erased subject's data (no resurrection).
 --
 -- payload_value is named with a prefix because "value" is a reserved word in several engines
 -- (H2, MySQL); it holds the externalised PII in clear text at rest, so protect this table at rest
 -- (DB-level encryption, least-privilege grants) exactly as you would the data it replaces inline.
+--
+-- TEXT (unbounded) is used instead of VARCHAR(4096) because the primary use case is free-text PII
+-- (operator notes, comments) that can easily exceed 4096 characters. TEXT is the standard
+-- unlimited-length character type on PostgreSQL, MariaDB, MySQL, and H2. Oracle users: use CLOB.
 CREATE TABLE IF NOT EXISTS gdpr_forgettable_payload (
     subject_id    VARCHAR(255)  NOT NULL,
     field_key     VARCHAR(255)  NOT NULL,
-    payload_value VARCHAR(4096),                -- the externalised PII; NULL on the tombstone row
+    payload_value TEXT,                         -- the externalised PII; NULL on the tombstone row
     updated_at    TIMESTAMP     NOT NULL,
     erased_at     TIMESTAMP,                    -- non-NULL on the reserved tombstone row = erased
     PRIMARY KEY (subject_id, field_key)

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStorePostgresIT.java
@@ -1,0 +1,127 @@
+package com.iambilotta.gdpr.starter.erasure.forgettable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the bundled V3 Flyway migration applies cleanly on a real PostgreSQL 16 container
+ * and that {@link JdbcForgettablePayloadStore} round-trips payloads against the migrated schema.
+ *
+ * <p>This test was absent when commit 47afe07 fixed the NUL-byte tombstone issue; the forgettable
+ * store was therefore broken on Postgres despite H2 tests passing. This IT closes that gap so the
+ * Postgres path is part of the gate (mirroring {@code JdbcAuditSinkPostgresIT}).
+ *
+ * <p>Skipped when Docker is not available. Enable with {@code -Dspring-gdpr.it=true}.
+ */
+@Testcontainers
+@EnabledIfSystemProperty(named = "spring-gdpr.it", matches = "true")
+class JdbcForgettablePayloadStorePostgresIT {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("gdpr")
+            .withUsername("gdpr")
+            .withPassword("gdpr");
+
+    private static PGSimpleDataSource dataSource;
+
+    @BeforeAll
+    static void applyMigration() throws IOException {
+        dataSource = new PGSimpleDataSource();
+        dataSource.setURL(POSTGRES.getJdbcUrl());
+        dataSource.setUser(POSTGRES.getUsername());
+        dataSource.setPassword(POSTGRES.getPassword());
+
+        String migrationSql;
+        try (InputStream in = JdbcForgettablePayloadStorePostgresIT.class.getResourceAsStream(
+                "/db/migration/V3__gdpr_forgettable_payload.sql")) {
+            if (in == null) {
+                throw new IllegalStateException("V3 migration script not on classpath");
+            }
+            migrationSql = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        new JdbcTemplate(dataSource).execute(migrationSql);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (dataSource != null) {
+            new JdbcTemplate(dataSource).execute("DROP TABLE IF EXISTS gdpr_forgettable_payload");
+        }
+    }
+
+    private JdbcForgettablePayloadStore store() {
+        // autoCreateSchema=false: verifies the store works against the Flyway-applied schema,
+        // not the bootstrapSchema() DDL, so the two paths stay in sync.
+        return new JdbcForgettablePayloadStore(dataSource, "gdpr_forgettable_payload", false);
+    }
+
+    /**
+     * @spec.given the V3 Flyway migration applied to a real PostgreSQL 16 database
+     * @spec.when  a value is put and resolved
+     * @spec.then  the store works against the migrated schema (migration is Postgres-compatible)
+     * @spec.adr   ADR-0010
+     * @spec.us    REQ-GDPR-022
+     */
+    @Test
+    void putAndResolveAgainstMigratedPostgresSchema() {
+        JdbcForgettablePayloadStore store = store();
+
+        store.put("alice-1", "full_name", "Alice Liddell");
+
+        assertThat(store.resolve("alice-1", "full_name")).contains("Alice Liddell");
+    }
+
+    /**
+     * @spec.given the V3 Flyway migration applied to PostgreSQL (payload_value is TEXT, not VARCHAR)
+     * @spec.when  a free-text value longer than 4096 characters is stored and resolved
+     * @spec.then  the full value round-trips without truncation on Postgres
+     * @spec.adr   ADR-0010
+     * @spec.us    REQ-GDPR-022
+     */
+    @Test
+    void largeFreetextPayloadRoundTripsOnPostgres() {
+        JdbcForgettablePayloadStore store = store();
+        // 8 000-char string: representative of a long operator note / comment (the canonical
+        // FORGETTABLE_PAYLOAD use case). Would overflow the old VARCHAR(4096) cap.
+        String longNote = "B".repeat(8_000);
+
+        store.put("bob-2", "operator_note", longNote);
+
+        assertThat(store.resolve("bob-2", "operator_note")).contains(longNote);
+    }
+
+    /**
+     * @spec.given a subject with fields stored on Postgres
+     * @spec.when  the subject is erased
+     * @spec.then  the tombstone is written using the plain '__erased__' reserved key (no NUL byte)
+     *             and every resolved field is empty afterwards
+     * @spec.adr   ADR-0010
+     * @spec.us    REQ-GDPR-022
+     */
+    @Test
+    void erasureWritesTombstoneAndDeletesFieldsOnPostgres() {
+        JdbcForgettablePayloadStore store = store();
+        store.put("carol-3", "email", "carol@example.com");
+        store.put("carol-3", "full_name", "Carol Danvers");
+
+        int deleted = store.erase("carol-3");
+
+        assertThat(deleted).isEqualTo(2);
+        assertThat(store.resolve("carol-3", "email")).isEmpty();
+        assertThat(store.resolve("carol-3", "full_name")).isEmpty();
+    }
+}

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/erasure/forgettable/JdbcForgettablePayloadStoreTest.java
@@ -161,6 +161,25 @@ class JdbcForgettablePayloadStoreTest {
     }
 
     /**
+     * @spec.given a free-text PII value longer than 4096 characters (the old VARCHAR cap)
+     * @spec.when  that value is stored and resolved
+     * @spec.then  the full value round-trips without truncation (payload_value is TEXT, unbounded)
+     * @spec.adr   ADR-0010
+     * @spec.us    REQ-GDPR-022
+     */
+    @Test
+    void handlesLargeFreetextPayloadBeyondOldVarcharLimit() {
+        JdbcForgettablePayloadStore store = store();
+        // 8 000-char string: well above the old VARCHAR(4096) cap, representative of a long
+        // operator note or free-text comment (the canonical FORGETTABLE_PAYLOAD use case).
+        String longNote = "A".repeat(8_000);
+
+        store.put("alice-1", "operator_note", longNote);
+
+        assertThat(store.resolve("alice-1", "operator_note")).contains(longNote);
+    }
+
+    /**
      * @spec.given a hostile table name that is not a bare SQL identifier
      * @spec.when  the store is constructed with it
      * @spec.then  construction fails fast before any SQL is built (injection-safe)


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled on one branch because they are both small and independent.

### fix(forgettable): widen payload_value from VARCHAR(4096) to TEXT

The primary use case of the forgettable-payload store is free-text PII (operator notes, comments). These easily exceed 4 096 characters, causing `put` to fail with a DB truncation/overflow error — the exact use case the store is advertised for.

Changes:
- `V3__gdpr_forgettable_payload.sql`: `payload_value VARCHAR(4096)` → `payload_value TEXT`
- `JdbcForgettablePayloadStore.bootstrapSchema()`: same change, so the in-memory-create and Flyway paths stay in sync
- DDL header comment: updated the Oracle note (CLOB instead of VARCHAR)
- New H2 unit test `handlesLargeFreetextPayloadBeyondOldVarcharLimit`: an 8 000-char payload round-trips through the H2-backed store
- New `JdbcForgettablePayloadStorePostgresIT` (Testcontainers, `-Dspring-gdpr.it=true`): closes the Postgres coverage gap noted in commit 47afe07; three scenarios covering basic put/resolve, large TEXT payload, and tombstone erasure on a real Postgres 16 container

Closes #33

### docs(readme): document JitPack authentication requirement for consumers

Adopters resolving `spring-gdpr-starter` from a fresh CI environment hit HTTP 401 from `jitpack.io` even though the repo is public. Added a callout block under **Quick start > Step 1** covering:
- Why the 401 happens and what to check first
- How to obtain the free personal token from jitpack.io
- Maven: `settings.xml` `<server>` block with `${env.JITPACK_TOKEN}` so the token stays out of source control
- Gradle: `gradle.properties` key + `build.gradle.kts` credentials block
- Link to JitPack docs for further detail

Closes #32

## Test plan

- [ ] `./mvnw -q verify` — green (run locally, confirmed)
- [ ] `tracegate . --check` — drift-gate passes (exit 0, confirmed)
- [ ] `./mvnw -Dspring-gdpr.it=true verify` — runs `JdbcForgettablePayloadStorePostgresIT` against Postgres 16 (requires Docker; gated)
- [ ] README: verify the new callout block renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)