### PR TITLE
chore(scm): integration-regen hooks (sw-scm-007) + version single-source-of-truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ generated-sources/spring.gdpr/
 
 # maven-shade-plugin artifacts
 **/dependency-reduced-pom.xml
+
+# flatten-maven-plugin: CI-friendly ${revision} resolution writes this transient pom
+# during the build (removed by `mvn clean` via flatten:clean); never committed.
+**/.flattened-pom.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# pre-commit framework config (https://pre-commit.com).
+#
+# Install once per clone:   make setup   (installs tracegate pinned + pre-commit hooks)
+# Run on demand:            pre-commit run --all-files
+#
+# This repo's _generated/ catalog is a WHOLE-TREE derived artifact (tracegate reads every
+# module's test suite). It must stay in lockstep with the code, and CI drift-gates it
+# (`tracegate . --check`, the `tracegate` job). The hooks below regenerate + auto-stage it
+# on every tree-mutating operation so the gate can never catch drift the local dev didn't see.
+#
+# The generator is the OSS tool tracegate, pinned by Makefile TRACEGATE_REF (kept in lockstep
+# with the CI job's env). `make setup` installs that exact pin onto PATH.
+repos:
+  - repo: local
+    hooks:
+      - id: regen-generated-docs
+        name: regenerate */_generated/*.md + auto-stage
+        # Idempotent: clean tree -> byte-identical output -> no-op. Running it on every commit
+        # is what makes the catalog unable to drift away from the code.
+        entry: scripts/hooks/regen-docs-and-stage.sh
+        language: script
+        always_run: true
+        pass_filenames: false
+
+      - id: regen-generated-docs-on-integration
+        name: regenerate */_generated/*.md + auto-stage (after merge/rebase/cherry-pick)
+        # ADR sw-scm-007: */_generated is a WHOLE-TREE derived artifact. The pre-commit hook
+        # above fires only on `git commit`; merge / pull / rebase-pick / cherry-pick REPLAY
+        # existing commits and bypass it, so integrating several branches yields an HEAD whose
+        # _generated was regenerated against the union by nobody. These two post-* stages run
+        # the SAME pinned-tracegate regen + auto-stage after every tree-mutating integration
+        # op, so the integrated HEAD is consistent without a manual `make requirements`.
+        # Idempotent: no change in the tree -> no-op. They run AFTER the operation, so they only
+        # stage the regen for the next commit, they never create a commit themselves.
+        entry: scripts/hooks/regen-docs-and-stage.sh
+        language: script
+        stages: [post-merge, post-rewrite]
+        always_run: true
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-# spring-gdpr — local regen of the living requirements catalog (tracegate).
+# spring-gdpr — local regen of the living requirements catalog (tracegate) + git hooks.
 #
 # The Java build stays on Maven (`./mvnw verify`); this Makefile only drives the
 # tracegate dogfood loop so contributors can regenerate / drift-check the
-# committed `*/_generated/` catalog the same way CI does.
+# committed `*/_generated/` catalog the same way CI does, and installs the git
+# hooks that keep that catalog from drifting.
 #
+#   make setup               one-shot per clone: install pinned tracegate + git hooks
 #   make requirements        regenerate every module's _generated/ catalog
 #   make requirements-check  drift-gate: exit 2 if the catalog drifted from the code
 #   make tracegate-install   install tracegate, pinned to the CI commit
+#   make install-hooks       install the pre-commit framework hooks (commit + post-merge/post-rewrite)
 #
 # The catalog is GENERATED — never hand-edit a `_generated/*` file. To change a
 # requirement, change the test (rename it, add a @spec javadoc) and rerun `make
@@ -17,15 +20,23 @@
 TRACEGATE_REF ?= 3bb94964f1e0502d2e68681611bf5ac335180f4b
 TRACEGATE_PKG := git+https://github.com/iambilotta/tracegate@$(TRACEGATE_REF)
 PIP ?= python3 -m pip
+# PEP 668: a system Python refuses `pip install` without this; harmless on a venv.
+PIP_FLAGS ?= --break-system-packages
 
-.PHONY: help requirements requirements-check tracegate-install
+.PHONY: help setup requirements requirements-check tracegate-install install-hooks
 
 help:  ## show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
 		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
+setup: tracegate-install install-hooks  ## one-shot per clone: pinned tracegate + git hooks
+	@echo "setup complete: tracegate pinned to $(TRACEGATE_REF), git hooks installed"
+
 tracegate-install:  ## install tracegate, pinned to the CI commit
-	$(PIP) install --quiet "$(TRACEGATE_PKG)"
+	$(PIP) install --quiet $(PIP_FLAGS) "$(TRACEGATE_PKG)"
+
+install-hooks:  ## install pre-commit hooks (pre-commit + post-merge + post-rewrite, ADR sw-scm-007)
+	scripts/install-git-hooks.sh
 
 requirements:  ## regenerate the as-built requirements catalog (writes each module's _generated/)
 	tracegate .

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.iambilotta.gdpr</groupId>
     <artifactId>spring-gdpr-parent</artifactId>
-    <version>2.0.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>spring-gdpr (parent)</name>
@@ -48,6 +48,11 @@
     </modules>
 
     <properties>
+        <!-- Single source of the reactor version (Maven CI-friendly versions). Every module
+             coordinate inherits it via ${revision}; bump here only. flatten-maven-plugin
+             resolves it in the installed/deployed poms so consumers never see the literal. -->
+        <revision>2.0.0</revision>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>21</maven.compiler.release>
@@ -68,6 +73,7 @@
         <maven-plugin-plugin.version>3.15.2</maven-plugin-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
+        <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -177,10 +183,42 @@
                         </java>
                     </configuration>
                 </plugin>
+                <!-- Maven CI-friendly versions: ${revision} is the literal version Maven
+                     reads, but the installed/deployed poms must carry the resolved value so
+                     consumers (and JitPack) never see the unresolved property. resolveCiFriendliesOnly
+                     rewrites only ${revision}/${sha1}/${changelist}, leaving the rest of the pom intact.
+                     Inherited by every module; no child needs to redeclare it. -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${flatten-maven-plugin.version}</version>
+                    <configuration>
+                        <updatePomFile>true</updatePomFile>
+                        <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals><goal>flatten</goal></goals>
+                        </execution>
+                        <execution>
+                            <id>flatten-clean</id>
+                            <phase>clean</phase>
+                            <goals><goal>clean</goal></goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <!-- Activate the CI-friendly version flattening for the whole reactor (config +
+                 executions inherited from pluginManagement above). -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/scripts/hooks/regen-docs-and-stage.sh
+++ b/scripts/hooks/regen-docs-and-stage.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regenerate every module's `_generated/` catalog and auto-stage the results.
+# Idempotent: a clean tree regenerates byte-identical output, so `git add` is a no-op.
+# Owned by .pre-commit-config.yaml; do not call directly (use `make requirements` for that).
+#
+# The generator is the OSS tool `tracegate` (github.com/iambilotta/tracegate), installed
+# pinned by `make setup` (-> make tracegate-install). The pin is the single source of the
+# version (Makefile TRACEGATE_REF, kept in lockstep with the CI `tracegate` job). Running an
+# UNPINNED tracegate here regenerates a different catalog than CI gates against -> false drift,
+# so the pinned install is load-bearing, not a nicety.
+#
+# Apps + labels are NOT passed on the command line: this repo registers them in tracegate.toml
+# (deterministic labels across machines/CI, see that file). The zero-config `tracegate .` is the
+# same invocation `make requirements` and the CI drift-gate (`tracegate . --check`) use.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if ! command -v tracegate >/dev/null 2>&1; then
+  echo "tracegate not found on PATH. Run 'make setup' (or 'make tracegate-install') once per clone." >&2
+  exit 1
+fi
+
+# Regenerate every registered module's catalog into its committed `_generated/` dir.
+tracegate . >/dev/null
+
+# Stage every generated artifact (the .md docs AND requirements.json, the machine view the
+# CI drift-gate also verifies) EXCEPT the gitignored ones. `coverage.md` is tracked here but is
+# only refreshed when the JaCoCo CSV exists; tracegate leaves it untouched otherwise (soft-skip),
+# so staging it is a no-op on the common path.
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  # A gitignored generated artifact would make `git add` exit non-zero under `set -e` and kill
+  # the hook on every commit; skip it explicitly (none are ignored today, but keep it robust).
+  git check-ignore -q "$f" && continue
+  git add "$f"
+done < <(find . -type d -name _generated -prune -exec find {} -type f \;)

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install this repo's git hooks via the pre-commit framework (https://pre-commit.com):
+# declarative config in .pre-commit-config.yaml, every tool version pinned, hook
+# environments isolated. This script is the stable entry point (`make setup` calls it).
+#
+# Stages installed: pre-commit PLUS post-merge + post-rewrite. The post-* stages regenerate
+# the WHOLE-TREE tracegate `_generated/` catalog after merge / pull / rebase / cherry-pick:
+# operations that REPLAY existing commits and so never fire the pre-commit hook (ADR
+# sw-scm-007). Without them, integrating several branches yields an HEAD whose `_generated`
+# matches no single branch and was regenerated against the union by nobody, and the CI
+# `tracegate` drift-gate then catches it late.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v pre-commit >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/pre-commit" ]; then
+  echo "pre-commit not found. Install it:" >&2
+  echo "  pip3 install --user --break-system-packages pre-commit" >&2
+  exit 1
+fi
+
+PRE_COMMIT="$(command -v pre-commit || echo "$HOME/.local/bin/pre-commit")"
+
+# pre-commit refuses to `install` while core.hooksPath is set ("Cowardly refusing..."), even
+# when it points at the default location. If a clone/worktree sets the override (some do, to
+# share hooks across worktrees), drop it for the duration of the install (pre-commit writes
+# into the common .git/hooks, which is where any sane override points anyway), then restore it.
+COMMON_HOOKS="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"
+SAVED_HOOKS_PATH="$(git config --get core.hooksPath || true)"
+if [ -n "$SAVED_HOOKS_PATH" ]; then
+  git config --unset-all core.hooksPath
+  restore_hooks_path() { git config core.hooksPath "$SAVED_HOOKS_PATH"; }
+  trap restore_hooks_path EXIT
+fi
+
+"$PRE_COMMIT" install
+"$PRE_COMMIT" install --hook-type post-merge --hook-type post-rewrite
+echo "git hooks installed (pre-commit framework, config: .pre-commit-config.yaml)"
+echo "  stages: pre-commit, post-merge, post-rewrite"

--- a/spring-gdpr-annotations/pom.xml
+++ b/spring-gdpr-annotations/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-annotations</artifactId>

--- a/spring-gdpr-benchmark/pom.xml
+++ b/spring-gdpr-benchmark/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-benchmark</artifactId>

--- a/spring-gdpr-maven-plugin/pom.xml
+++ b/spring-gdpr-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-maven-plugin</artifactId>

--- a/spring-gdpr-processor/pom.xml
+++ b/spring-gdpr-processor/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-processor</artifactId>

--- a/spring-gdpr-starter-test/pom.xml
+++ b/spring-gdpr-starter-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-starter-test</artifactId>

--- a/spring-gdpr-starter/pom.xml
+++ b/spring-gdpr-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.iambilotta.gdpr</groupId>
         <artifactId>spring-gdpr-parent</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>spring-gdpr-starter</artifactId>


### PR DESCRIPTION
Brings spring-gdpr to the canonical sw-scm-007 pattern (promoted yokoten from housetree #119) and closes the one real release-readiness gap. Separate-repo work, no coordination with other branches.

## What this adds

### 1. sw-scm-007 integration-regen hooks (the main task)
The committed `*/_generated/` tracegate catalog is a WHOLE-TREE derived artifact and CI drift-gates it (`tracegate . --check`), but the repo had **no git hooks at all**, only a manual `make requirements`. The pre-commit framework fires only on `git commit`, so merge / pull / rebase-pick / cherry-pick replay existing commits and bypass regen, producing an integrated HEAD whose catalog matches no single branch (ADR sw-scm-007).

- `.pre-commit-config.yaml`: a local `regen-generated-docs` hook on the commit stage **plus** the same hook on `post-merge` / `post-rewrite`, so every tree-mutating integration op keeps the catalog in lockstep.
- `scripts/hooks/regen-docs-and-stage.sh`: runs the pinned tracegate (`tracegate .`, apps/labels from `tracegate.toml`) and auto-stages every `_generated/*` except gitignored ones. Idempotent: a clean tree regenerates byte-identical output, so it is a no-op.
- `scripts/install-git-hooks.sh`: installs commit + post-merge + post-rewrite, dropping/restoring `core.hooksPath` for the install (pre-commit refuses to install while it is set), mirroring housetree #119.
- `make setup` = `tracegate-install` + `install-hooks`; `PIP_FLAGS=--break-system-packages` for PEP 668 systems.

### 2. Version single-source-of-truth
`2.0.0` was hand-duplicated across the parent + all 6 module poms (a bump = 7-file edit). Adopted Maven CI-friendly versions: one `<revision>2.0.0</revision>` property, every coordinate `${revision}`, flatten-maven-plugin 1.7.3 in `resolveCiFriendliesOnly` mode so installed/deployed poms (and JitPack consumers) resolve a concrete `2.0.0` and never see the literal property. `.flattened-pom.xml` gitignored.

## What was already fine (NOT touched)
- **jitpack.yml**: correct JDK (openjdk21, matches `<java.version>21</java.version>`). Left as-is.
- **CI verify**: `ci.yml` runs a real `mvn -B verify` (incl. Postgres IT) + the tracegate drift-gate. Not stubbed. Left as-is.
- **Release machinery**: `pom.xml` already has a complete `release` profile (maven-source + maven-javadoc + maven-gpg + central-publishing, all with proper executions) and `distributionManagement` -> Central. README states Maven Central is deliberately not planned (JitPack-only, ADR-0005); the GPG/Central path is present for sister-repo parity. Left as-is.
- **Org/groupId consistency**: `iambilotta/spring-gdpr` + `com.iambilotta.gdpr` everywhere (pom scm/url, README, JitPack badge, install snippet). No ambiguity. Left as-is.
- **README install snippet**: JitPack `<repository>` + starter `<dependency>` present. Left as-is.
- **examples/quickstart-postgres**: standalone non-reactor project (own `0.1.0-SNAPSHOT`, references the starter via `${spring-gdpr.version}`); correctly decoupled, not part of the version SoT. Left as-is.

## Verification
- `mvn -DskipTests install` + full `mvn verify` (with tests): BUILD SUCCESS.
- Flattened starter pom carries `<version>2.0.0</version>` (not `${revision}`); `flatten:clean` removes the transient poms on `mvn clean`.
- `make requirements-check` (pinned tracegate): exit 0, catalog stable. **Note**: the locally-installed tracegate 1.4.0 reports false drift; only the pinned ref (`3bb94964`, == Makefile + CI) is clean. The regen scripts rely on `make setup` installing that pin.
- Hooks smoke-tested with the pinned tracegate: a scratch merge fired `post-merge`, a scratch rebase fired `post-rewrite`; both regenerated idempotently (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)