### PR TITLE
chore(scm): run tracegate through the pinned uvx env, never bare PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,12 @@ jobs:
     name: tracegate drift-gate
     runs-on: ubuntu-latest
     env:
-      # Keep in lockstep with the Makefile's TRACEGATE_REF.
+      # Single source of the pin: the Makefile's TRACEGATE_REF. CI runs the SAME pinned uvx
+      # invocation as the local hooks (uvx --from git+...@TRACEGATE_REF tracegate), so a stale
+      # PATH install can never make local and CI disagree.
       TRACEGATE_REF: 3bb94964f1e0502d2e68681611bf5ac335180f4b
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install tracegate (pinned)
-        run: pip install "git+https://github.com/iambilotta/tracegate@${TRACEGATE_REF}"
-      - name: Drift-gate the requirements catalog
-        run: tracegate . --check
+      - uses: astral-sh/setup-uv@v5
+      - name: Drift-gate the requirements catalog (pinned tracegate via uvx)
+        run: uvx --from "git+https://github.com/iambilotta/tracegate@${TRACEGATE_REF}" tracegate . --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,17 +8,20 @@
 # (`tracegate . --check`, the `tracegate` job). The hooks below regenerate + auto-stage it
 # on every tree-mutating operation so the gate can never catch drift the local dev didn't see.
 #
-# The generator is the OSS tool tracegate, pinned by Makefile TRACEGATE_REF (kept in lockstep
-# with the CI job's env). `make setup` installs that exact pin onto PATH.
+# The generator is the OSS tool tracegate, run through the PINNED uvx env (Makefile
+# TRACEGATE_REF, kept in lockstep with the CI job's env; see scripts/hooks/tracegate-pinned.sh),
+# never a bare PATH `tracegate`. `make setup` only verifies uv is present + warms the cache.
 repos:
   - repo: local
     hooks:
       - id: regen-generated-docs
         name: regenerate */_generated/*.md + auto-stage
         # Idempotent: clean tree -> byte-identical output -> no-op. Running it on every commit
-        # is what makes the catalog unable to drift away from the code.
+        # is what makes the catalog unable to drift away from the code. Scoped to pre-commit:
+        # integration ops are covered by the post-merge/post-rewrite hook below.
         entry: scripts/hooks/regen-docs-and-stage.sh
         language: script
+        stages: [pre-commit]
         always_run: true
         pass_filenames: false
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make setup               one-shot per clone: install pinned tracegate + git hooks
 #   make requirements        regenerate every module's _generated/ catalog
 #   make requirements-check  drift-gate: exit 2 if the catalog drifted from the code
-#   make tracegate-install   install tracegate, pinned to the CI commit
+#   make tracegate-install   verify uv is present + warm the pinned-tracegate uvx cache
 #   make install-hooks       install the pre-commit framework hooks (commit + post-merge/post-rewrite)
 #
 # The catalog is GENERATED — never hand-edit a `_generated/*` file. To change a
@@ -19,9 +19,12 @@
 # Pin tracegate to the exact commit CI uses, so local and CI agree byte-for-byte.
 TRACEGATE_REF ?= 3bb94964f1e0502d2e68681611bf5ac335180f4b
 TRACEGATE_PKG := git+https://github.com/iambilotta/tracegate@$(TRACEGATE_REF)
-PIP ?= python3 -m pip
-# PEP 668: a system Python refuses `pip install` without this; harmless on a venv.
-PIP_FLAGS ?= --break-system-packages
+# The pin footgun (sw-scm-005 made enforced): a bare `tracegate` resolves whatever the
+# contributor last `pip install`-ed on PATH, which may differ from TRACEGATE_REF and produce
+# FALSE drift against the committed _generated/ + the CI drift-gate's pinned generator. So EVERY
+# invocation goes through uvx, which builds an ephemeral, exactly-pinned env from TRACEGATE_PKG
+# (cached after the first run, no global pollution). Never call bare `tracegate` in a target/script.
+TRACEGATE := uvx --from "$(TRACEGATE_PKG)" tracegate
 
 .PHONY: help setup requirements requirements-check tracegate-install install-hooks
 
@@ -30,16 +33,22 @@ help:  ## show this help
 		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
 setup: tracegate-install install-hooks  ## one-shot per clone: pinned tracegate + git hooks
-	@echo "setup complete: tracegate pinned to $(TRACEGATE_REF), git hooks installed"
+	@echo "setup complete: tracegate pinned to $(TRACEGATE_REF) (via uvx), git hooks installed"
 
-tracegate-install:  ## install tracegate, pinned to the CI commit
-	$(PIP) install --quiet $(PIP_FLAGS) "$(TRACEGATE_PKG)"
+tracegate-install:  ## verify uv is present + warm the pinned-tracegate uvx cache (no global install)
+	# tracegate is no longer installed globally (that was the pin footgun: a stale PATH
+	# `tracegate` shadows the pin and produces FALSE drift). Every target/script runs it via
+	# uvx, an ephemeral exactly-pinned env. This target only checks uv exists and warms the cache.
+	@command -v uvx >/dev/null 2>&1 || { \
+	  echo "uv/uvx not found. Install it: https://docs.astral.sh/uv/getting-started/installation/" >&2; \
+	  exit 1; }
+	$(TRACEGATE) --help >/dev/null
 
 install-hooks:  ## install pre-commit hooks (pre-commit + post-merge + post-rewrite, ADR sw-scm-007)
 	scripts/install-git-hooks.sh
 
 requirements:  ## regenerate the as-built requirements catalog (writes each module's _generated/)
-	tracegate .
+	$(TRACEGATE) .
 
 requirements-check:  ## drift-gate: fail (exit 2) if the committed catalog drifted from the code
-	tracegate . --check
+	$(TRACEGATE) . --check

--- a/scripts/hooks/regen-docs-and-stage.sh
+++ b/scripts/hooks/regen-docs-and-stage.sh
@@ -3,11 +3,10 @@
 # Idempotent: a clean tree regenerates byte-identical output, so `git add` is a no-op.
 # Owned by .pre-commit-config.yaml; do not call directly (use `make requirements` for that).
 #
-# The generator is the OSS tool `tracegate` (github.com/iambilotta/tracegate), installed
-# pinned by `make setup` (-> make tracegate-install). The pin is the single source of the
-# version (Makefile TRACEGATE_REF, kept in lockstep with the CI `tracegate` job). Running an
-# UNPINNED tracegate here regenerates a different catalog than CI gates against -> false drift,
-# so the pinned install is load-bearing, not a nicety.
+# The generator is the OSS tool `tracegate` (github.com/iambilotta/tracegate). It is run
+# through `uvx` pinned to the Makefile's TRACEGATE_REF (the single source of the pin, kept in
+# lockstep with the CI `tracegate` job), NEVER a bare PATH `tracegate`: a stale PATH install
+# regenerates a different catalog than CI gates against -> FALSE drift. See tracegate-pinned.sh.
 #
 # Apps + labels are NOT passed on the command line: this repo registers them in tracegate.toml
 # (deterministic labels across machines/CI, see that file). The zero-config `tracegate .` is the
@@ -17,13 +16,12 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-if ! command -v tracegate >/dev/null 2>&1; then
-  echo "tracegate not found on PATH. Run 'make setup' (or 'make tracegate-install') once per clone." >&2
-  exit 1
-fi
+# Defines the pinned `TRACEGATE` array (uvx --from git+...@TRACEGATE_REF tracegate) + guards.
+# shellcheck source=scripts/hooks/tracegate-pinned.sh
+source "$(dirname "${BASH_SOURCE[0]}")/tracegate-pinned.sh"
 
 # Regenerate every registered module's catalog into its committed `_generated/` dir.
-tracegate . >/dev/null
+"${TRACEGATE[@]}" . >/dev/null
 
 # Stage every generated artifact (the .md docs AND requirements.json, the machine view the
 # CI drift-gate also verifies) EXCEPT the gitignored ones. `coverage.md` is tracked here but is

--- a/scripts/hooks/tracegate-pinned.sh
+++ b/scripts/hooks/tracegate-pinned.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+# Resolve the PINNED tracegate invocation for shell hooks/scripts.
+#
+# The pin footgun (sw-scm-005 made enforced, RFC 0024 sibling): a bare `tracegate` resolves
+# whatever the contributor last `pip install`-ed on PATH. If that differs from TRACEGATE_REF,
+# the regen produces output that disagrees with the committed _generated/ AND with CI's pinned
+# drift-gate -> FALSE drift. So scripts NEVER call bare `tracegate`; they call the array
+# `TRACEGATE[@]` defined here, which runs the generator via `uvx` in an ephemeral env pinned
+# to TRACEGATE_REF (cached after the first run, no global pollution).
+#
+# Single source of the pin: the Makefile's `TRACEGATE_REF`. We parse it from there so the hook,
+# the Makefile and the CI job cannot drift apart (the failure mode this file exists to kill).
+#
+# Usage:
+#   source "$(dirname "$0")/tracegate-pinned.sh"   # defines the TRACEGATE array
+#   "${TRACEGATE[@]}" .            # regen
+#   "${TRACEGATE[@]}" . --check    # drift-gate
+set -euo pipefail
+
+_TG_ROOT="$(git rev-parse --show-toplevel)"
+
+# Read TRACEGATE_REF from the Makefile (single source of truth). `?=` or `:=` form.
+TRACEGATE_REF="$(sed -n 's/^TRACEGATE_REF[[:space:]]*[?:]\{0,1\}=[[:space:]]*\([0-9a-f]\{7,\}\).*/\1/p' "$_TG_ROOT/Makefile" | head -n1)"
+if [ -z "${TRACEGATE_REF:-}" ]; then
+  echo "FATAL: could not read TRACEGATE_REF from $_TG_ROOT/Makefile (the single source of the pin)." >&2
+  exit 1
+fi
+TRACEGATE_PKG="git+https://github.com/iambilotta/tracegate@${TRACEGATE_REF}"
+
+if ! command -v uvx >/dev/null 2>&1; then
+  echo "FATAL: uv/uvx not found. tracegate runs ONLY through the pinned uvx env (no global install)." >&2
+  echo "Install uv: https://docs.astral.sh/uv/getting-started/installation/ then re-run 'make setup'." >&2
+  exit 1
+fi
+
+# The pinned invocation. Always exactly TRACEGATE_REF; a stale PATH `tracegate` is never used.
+# Consumed by the scripts that source this file (SC2034: used externally, not in this file).
+# shellcheck disable=SC2034
+TRACEGATE=(uvx --from "${TRACEGATE_PKG}" tracegate)


### PR DESCRIPTION
## The footgun

Every regen invocation (`make requirements`, `make requirements-check`, the regen pre-commit / post-merge / post-rewrite hooks, the CI drift-gate) called bare `tracegate`, resolved from PATH. A contributor whose globally-installed tracegate differs from `TRACEGATE_REF` would regenerate a catalog that disagrees with the committed `_generated/` **and** with CI's pinned generator, producing **FALSE drift**. This is the `sw-scm-005` pin discipline made *enforced*, not advisory (sibling of RFC 0024 / ADR sw-scm-007).

## Fix

Every invocation now runs through `uvx --from "git+https://github.com/iambilotta/tracegate@${TRACEGATE_REF}" tracegate ...` — an ephemeral env built **exactly at the pin**, cached after the first run, no global pollution.

- **Makefile**: `TRACEGATE := uvx --from "$(TRACEGATE_PKG)" tracegate`; `requirements` + `requirements-check` use it. `tracegate-install` no longer installs globally — it verifies `uv` is present and warms the uvx cache.
- **`scripts/hooks/tracegate-pinned.sh`** (new): shared helper that parses `TRACEGATE_REF` from the Makefile (single source of the pin) and defines the pinned `TRACEGATE` array; **fails loudly if `uv` is absent** (no silent PATH fallback).
- **`scripts/hooks/regen-docs-and-stage.sh`**: sources the helper, uses the pinned array; scoped to `pre-commit` (integration covered by the post-merge/post-rewrite hook).
- **CI** (`.github/workflows/ci.yml`): installs `uv` via `astral-sh/setup-uv` and runs the **same** pinned uvx invocation as local, so local and CI cannot disagree.

## Determinism proof

- uvx genuinely honors the ref: an **older** ref produces **different** output (no silent PATH fallback).
- The hardened regen produces **ZERO** drift against the committed `_generated/`; re-running is **stable**.
- `tracegate . --check` (pinned via uvx) exits **0**.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)