### PR TITLE
fix(audit): no DB I/O in JdbcAuditSink constructor (CDS/AOT/native/no-DB-boot safe)

### DIFF
--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/GdprProperties.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/GdprProperties.java
@@ -60,6 +60,15 @@ public class GdprProperties {
          */
         private boolean autoCreateSchema = false;
 
+        /**
+         * Run the audit-store schema check (or {@code auto-create-schema} bootstrap) at startup, once the
+         * application is fully started. Default true (fail fast if the table is missing). Set false to skip
+         * ALL startup DB I/O for the audit sink, so the context can refresh without a live database: required
+         * for CDS/AOT training runs, GraalVM native builds, and no-DB test/dev boots. The sink still works at
+         * runtime; only the eager startup verification is skipped.
+         */
+        private boolean verifySchemaOnStartup = true;
+
         private final Async async = new Async();
 
         public boolean isJdbcEnabled() {
@@ -84,6 +93,14 @@ public class GdprProperties {
 
         public void setAutoCreateSchema(boolean autoCreateSchema) {
             this.autoCreateSchema = autoCreateSchema;
+        }
+
+        public boolean isVerifySchemaOnStartup() {
+            return verifySchemaOnStartup;
+        }
+
+        public void setVerifySchemaOnStartup(boolean verifySchemaOnStartup) {
+            this.verifySchemaOnStartup = verifySchemaOnStartup;
         }
 
         public Async getAsync() {

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/AsyncAuditSinkDecorator.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/AsyncAuditSinkDecorator.java
@@ -108,6 +108,11 @@ public class AsyncAuditSinkDecorator implements AuditSink, AutoCloseable {
         return delegate.findBySubject(subjectId, from, to);
     }
 
+    @Override
+    public void initializeSchema() {
+        delegate.initializeSchema();
+    }
+
     public long droppedCount() {
         return dropped.sum();
     }

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/AuditSink.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/AuditSink.java
@@ -12,6 +12,16 @@ public interface AuditSink {
     void write(AuditAccessRecord record);
 
     /**
+     * Bring the sink's backing store to a usable state (create or verify the schema). Called once by the
+     * autoconfig AFTER the application has started, never during bean construction, so a sink stays
+     * constructible without a live backing store (CDS/AOT training, native build, tests, pre-DB boot).
+     * Default: no-op (sinks with no schema, e.g. SLF4J).
+     */
+    default void initializeSchema() {
+        // no-op by default
+    }
+
+    /**
      * Read records for the right-of-access endpoint (Art. 15). Implementations that cannot
      * query (e.g. SLF4J-only) should throw {@link UnsupportedOperationException}.
      */

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/JdbcAuditSink.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/audit/JdbcAuditSink.java
@@ -34,6 +34,7 @@ public class JdbcAuditSink implements AuditSink {
 
     private final JdbcTemplate jdbc;
     private final String table;
+    private final boolean autoCreateSchema;
 
     public JdbcAuditSink(DataSource dataSource, String table) {
         this(dataSource, table, false);
@@ -42,6 +43,20 @@ public class JdbcAuditSink implements AuditSink {
     public JdbcAuditSink(DataSource dataSource, String table, boolean autoCreateSchema) {
         this.jdbc = new JdbcTemplate(dataSource);
         this.table = sanitize(table);
+        this.autoCreateSchema = autoCreateSchema;
+        // NO DB I/O in the constructor: a bean must be constructible without a live database, else CDS/AOT
+        // training runs, GraalVM native builds, tests and any boot before the DB is ready all fail at refresh.
+        // The schema check/bootstrap moved to {@link #initializeSchema()}, run by the autoconfig once the
+        // application is fully started (and skipped when the context exits at refresh, e.g. the CDS training run).
+    }
+
+    /**
+     * Bootstraps (auto-create) or verifies the audit table. Idempotent. Called by the autoconfig's
+     * startup runner on a real boot (DB available); never from the constructor, so the bean stays
+     * constructible without a database.
+     */
+    @Override
+    public void initializeSchema() {
         if (autoCreateSchema) {
             bootstrapSchema();
         } else {

--- a/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
+++ b/spring-gdpr-starter/src/main/java/com/iambilotta/gdpr/starter/autoconfig/GdprAutoConfiguration.java
@@ -8,6 +8,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -91,6 +92,22 @@ public class GdprAutoConfiguration {
         }
         return new AsyncAuditSinkDecorator(
                 base, async.getThreadCount(), async.getQueueCapacity(), async.getAwaitMillis());
+    }
+
+    /**
+     * Initializes the audit-store schema (verify, or {@code auto-create-schema} bootstrap) AFTER the
+     * application has fully started, never during bean construction. An {@link ApplicationRunner} runs after
+     * the context refresh, so on a real boot it still fails fast if the table is missing; but a context that
+     * exits at refresh (the CDS/AOT training run with {@code spring.context.exit=onRefresh}, a GraalVM native
+     * build, a no-DB test boot) never reaches the runner and so does no DB I/O. Disable via
+     * {@code spring.gdpr.audit.verify-schema-on-startup=false}.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "gdprAuditSchemaInitializer")
+    @ConditionalOnProperty(prefix = "spring.gdpr.audit", name = "verify-schema-on-startup",
+            havingValue = "true", matchIfMissing = true)
+    public ApplicationRunner gdprAuditSchemaInitializer(AuditSink sink) {
+        return args -> sink.initializeSchema();
     }
 
     private AuditSink buildBaseSink(GdprProperties properties, ObjectProvider<DataSource> dataSourceProvider) {

--- a/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/audit/JdbcAuditSinkTest.java
+++ b/spring-gdpr-starter/src/test/java/com/iambilotta/gdpr/starter/audit/JdbcAuditSinkTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JdbcAuditSinkTest {
@@ -29,6 +30,7 @@ class JdbcAuditSinkTest {
     @Test
     void writeAndQueryRoundTrip() {
         JdbcAuditSink sink = new JdbcAuditSink(dataSource, "gdpr_audit_access", true);
+        sink.initializeSchema();
 
         Instant t0 = Instant.parse("2030-01-01T10:00:00Z");
         Instant t1 = Instant.parse("2030-01-01T10:05:00Z");
@@ -49,6 +51,7 @@ class JdbcAuditSinkTest {
     @Test
     void filtersByTimeWindow() {
         JdbcAuditSink sink = new JdbcAuditSink(dataSource, "gdpr_audit_access", true);
+        sink.initializeSchema();
         sink.write(record("old", Instant.parse("2025-01-01T00:00:00Z"), "x", "T", "m", "6(1)(a)", false));
         sink.write(record("new", Instant.parse("2030-01-01T00:00:00Z"), "x", "T", "m", "6(1)(a)", false));
 
@@ -73,14 +76,30 @@ class JdbcAuditSinkTest {
     void schemaIsIdempotent() {
         JdbcAuditSink first = new JdbcAuditSink(dataSource, "gdpr_audit_access", true);
         JdbcAuditSink second = new JdbcAuditSink(dataSource, "gdpr_audit_access", true);
+        first.initializeSchema();
+        second.initializeSchema(); // bootstrapping a second time over the same table is a no-op
 
         second.write(record("after-second-bootstrap", Instant.now(), "x", "T", "m", "6(1)(a)", false));
         assertThat(first.findBySubject("x", null, null)).hasSize(1);
     }
 
     @Test
+    void constructorDoesNoDbIoSoTheBeanIsConstructibleWithoutADatabase() {
+        // The table is missing in the fresh H2 and autoCreate=false: the OLD constructor verified the table
+        // here and threw. The new constructor does NO DB I/O, so it must construct cleanly (CDS/AOT/native/
+        // no-DB-boot safe); the verification is deferred to initializeSchema() (see the fail-fast test).
+        assertThatCode(() -> new JdbcAuditSink(dataSource, "gdpr_audit_access", false))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> new JdbcAuditSink(dataSource, "gdpr_audit_access", true))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     void failsFastWhenTableMissingAndAutoCreateOff() {
-        assertThatThrownBy(() -> new JdbcAuditSink(dataSource, "gdpr_audit_access", false))
+        // The constructor does NO DB I/O (CDS/AOT/native/no-DB-boot safe); the fail-fast moved to
+        // initializeSchema(), which the autoconfig runs once the app has started.
+        JdbcAuditSink sink = new JdbcAuditSink(dataSource, "gdpr_audit_access", false);
+        assertThatThrownBy(sink::initializeSchema)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("not present")
                 .hasMessageContaining("V1__gdpr_audit_access.sql");
@@ -88,8 +107,9 @@ class JdbcAuditSinkTest {
 
     @Test
     void worksWhenTableExistsAndAutoCreateOff() {
-        new JdbcAuditSink(dataSource, "gdpr_audit_access", true);
+        new JdbcAuditSink(dataSource, "gdpr_audit_access", true).initializeSchema();
         JdbcAuditSink secondInstance = new JdbcAuditSink(dataSource, "gdpr_audit_access", false);
+        secondInstance.initializeSchema(); // table exists -> verify passes
 
         secondInstance.write(record("e1", Instant.now(), "alice", "T", "m", "6(1)(a)", false));
         assertThat(secondInstance.findBySubject("alice", null, null)).hasSize(1);


### PR DESCRIPTION
JdbcAuditSink verified/bootstrapped the audit table in its constructor, connecting to the DB at bean creation — breaks CDS/AOT training runs, GraalVM native builds, tests, and any boot before the DB is ready (fails at context refresh). Moved the schema verify/bootstrap to AuditSink#initializeSchema(), run by an autoconfig ApplicationRunner after the app starts: a real boot still fails fast if the table is missing, a context that exits at refresh does no DB I/O. Opt-out spring.gdpr.audit.verify-schema-on-startup=false (default true). 105 starter tests green + a new no-IO-constructor test.